### PR TITLE
currentTimeMillis() was returning microsecondonds

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -954,7 +954,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
 
   /** @return an approximate of the current time in milliseconds */
   protected long currentTimeMillis() {
-    return ticker.read() >> 10;
+    return ticker.read() >> 20;
   }
 
   /**


### PR DESCRIPTION
should divide by 1000000 (>> 20 => 1048576) not 1000 (>> 10 => 1024)