### PR TITLE
Update collision cache version and config.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ allprojects {
 
   repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-    maven { url 'http://dl.bintray.com/jamespedwards42/libs' }
     maven { url 'https://jitpack.io' }
     mavenCentral()
     jcenter()
@@ -47,10 +46,10 @@ subprojects {
   if (JavaVersion.current().isJava9Compatible()) {
     tasks.uploadArchives.enabled = false
   } else {
-    apply plugin: 'net.ltgt.errorprone'  
+    apply plugin: 'net.ltgt.errorprone'
   }
 
-  sourceCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_9
 
   group = 'com.github.ben-manes.caffeine'
   version.with {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -55,7 +55,7 @@ ext {
   ]
   benchmark_versions = [
     cache2k: '0.28-BETA',
-    collision: '0.1.0',
+    collision: '0.2.4',
     concurrentlinkedhashmap: '1.4.2',
     ehcache2: '2.10.2.2.21',
     ehcache3: '3.1.2',

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CollisionPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CollisionPolicy.java
@@ -15,20 +15,21 @@
  */
 package com.github.benmanes.caffeine.cache.simulator.policy.product;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.List;
-import java.util.Set;
-
-import org.apache.commons.lang3.text.WordUtils;
+import com.google.common.collect.ImmutableSet;
 
 import com.fabahaba.collision.cache.CollisionBuilder;
 import com.fabahaba.collision.cache.CollisionCache;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
-import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
+
+import org.apache.commons.lang3.text.WordUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Collision cache implementation.
@@ -50,10 +51,14 @@ public final class CollisionPolicy implements Policy {
     CollisionBuilder<Object> builder = CollisionCache
         .withCapacity(maximumSize)
         .setInitCount(settings.initCount())
-        .setBucketSize(settings.bucketSize());
+        .setStrictCapacity(settings.strictCapacity());
+
+    if(settings.bucketSize() > 0) {
+      builder.setBucketSize(settings.bucketSize());
+    }
 
     if (density == Density.SPARSE) {
-      cache = builder.buildSparse();
+      cache = builder.buildSparse(settings.sparseFactor());
     } else if (density == Density.PACKED) {
       cache = builder.buildPacked();
     } else {
@@ -101,6 +106,12 @@ public final class CollisionPolicy implements Policy {
     }
     public int bucketSize() {
       return config().getInt("collision.bucket-size");
+    }
+    public double sparseFactor() {
+      return config().getDouble("collision.sparse-factor");
+    }
+    public boolean strictCapacity() {
+      return config().getBoolean("collision.strict-capacity");
     }
     public List<Density> density() {
       return config().getStringList("collision.density").stream()

--- a/simulator/src/main/resources/reference.conf
+++ b/simulator/src/main/resources/reference.conf
@@ -40,65 +40,65 @@ caffeine.simulator {
 
   policies = [
     # Policies that provide an optimal upper bound
-    "opt.Unbounded",
-    "opt.Clairvoyant",
+    #"opt.Unbounded",
+    #"opt.Clairvoyant",
 
     # Policies based on maintaining a linked-list cross-cutting the hash table
-    "linked.Lru",
-    "linked.Mru",
-    "linked.Lfu",
-    "linked.Mfu",
-    "linked.Fifo",
-    "linked.Clock",
-    "linked.S4Lru",
-    "linked.MultiQueue",
-    "linked.SegmentedLru",
+    #"linked.Lru",
+    #"linked.Mru",
+    #"linked.Lfu",
+    #"linked.Mfu",
+    #linked.Fifo",
+    #"linked.Clock",
+    #"linked.S4Lru",
+    #"linked.MultiQueue",
+    #"linked.SegmentedLru",
 
     # Policies based on obtaining a random sampling from the hash table
-    "sampled.Lru",
-    "sampled.Mru",
-    "sampled.Lfu",
-    "sampled.Mfu",
-    "sampled.Fifo",
-    "sampled.Random",
+    #"sampled.Lru",
+    #"sampled.Mru",
+    #"sampled.Lfu",
+    #"sampled.Mfu",
+    #"sampled.Fifo",
+    #"sampled.Random",
 
     # Policies based on the 2Q algorithm
-    "two-queue.TwoQueue",
-    "two-queue.TuQueue",
+    #"two-queue.TwoQueue",
+    #"two-queue.TuQueue",
 
     # Policies based on a sketch algorithm
-    "sketch.WindowTinyLfu",
-    "sketch.S4WindowTinyLfu",
-    "sketch.SimpleWindowTinyLfu",
-    "sketch.RandomWindowTinyLfu",
-    "sketch.FullySegmentedWindowTinyLfu",
+    #"sketch.WindowTinyLfu",
+    #"sketch.S4WindowTinyLfu",
+    #"sketch.SimpleWindowTinyLfu",
+    #"sketch.RandomWindowTinyLfu",
+    #"sketch.FullySegmentedWindowTinyLfu",
 
-    "sketch.AdaptiveTinyLfu",
-    "sketch.AdaptiveWindowTinyLfu",
+    #"sketch.AdaptiveTinyLfu",
+    #"sketch.AdaptiveWindowTinyLfu",
 
-    "sketch.TinyCache",
-    "sketch.TinyCache_GhostCache",
-    "sketch.WindowTinyCache",
+    #"sketch.TinyCache",
+    #"sketch.TinyCache_GhostCache",
+    #"sketch.WindowTinyCache",
 
     # Policies based on the LIRS algorithm
-    "irr.Lirs",
-    "irr.ClockPro",
+    #"irr.Lirs",
+    #"irr.ClockPro",
 
     # Policies based on the ARC algorithm
-    "adaptive.Arc",
-    "adaptive.Car",
-    "adaptive.Cart",
+    #"adaptive.Arc",
+    #"adaptive.Car",
+    #"adaptive.Cart",
 
     # Caching products
-    "product.Guava",
-    "product.TCache",
+    #"product.Guava",
+    #"product.TCache",
     "product.Cache2k",
     "product.Caffeine",
-    "product.Ehcache2",
+    #"product.Ehcache2",
     "product.Ehcache3",
     "product.Collision",
-    "product.Infinispan",
-    "product.ElasticSearch",
+    #"product.Infinispan",
+    #"product.ElasticSearch",
   ]
 
   # The admission policy (opposite of eviction policy)
@@ -106,9 +106,9 @@ caffeine.simulator {
     "Always",
     "TinyLfu",
   ]
-  
+
   # The membership filter implementation: Caffeine, Guava, AddThis
-  membership-filter = "caffeine" 
+  membership-filter = "caffeine"
 
   sampling {
     # The random sample size
@@ -281,11 +281,13 @@ caffeine.simulator {
   }
 
   collision {
-    init-count = 5
-    bucket-size = 0
+    init-count = 1
+    bucket-size = 16
+    sparse-factor = 5.0
+    strict-capacity = true
 
     # Densities: Sparse, Packed
-    density = ["sparse", "packed"]
+    density = ["sparse"]
   }
 
   # files: reads from the trace file(s)
@@ -294,7 +296,7 @@ caffeine.simulator {
 
   files {
     # The paths to the trace files, or the file names if in the format's package
-    paths = [ "multi1.trace.gz" ]
+    paths = [ "multi3.trace.gz" ]
 
     # scarab: format of Scarab Research traces
     # address: format of UCSD program address traces


### PR DESCRIPTION
Finally ready to start messing around with the simulator, thanks for wiring everything up, this is very nice.  Awesome to get that immediate feedback after turning configuration knobs.

I need to rollback the changes I made to reference.conf here, but I wanted to ask, how did you run DS1 and glimpse mentioned on jamespedwards42/collision#1?  I downloaded DS1.lis from [Dharmendra S. Modha's page](http://researcher.watson.ibm.com/researcher/view_person_subpage.php?id=4700) and used the arc format, but I get less than 1% hit rates for all the caches.  Also, I couldn't figure out what trace file corresponds to glimpse.  And, is the number after the trace name the number of entries in that dataset or a simulator configuration? ... Everything worked as expected for mutli3.

I've added atomic loading by default, with an additional `getAggressive` method with the non-synchronized loading behavior.  Also, strict capacity is now the default behavior for sparse caches.

Working on updating the readme with a benchmark that shows, given a chance to sufficiently sample a dataset, caffeine will outperform everything.  Still going to have a couple of corner use cases that I think will be a good fit for collision.

Regarding the logarithmic counters for TinyLFU.  Feel free to copy paste [any of that stuff](https://github.com/jamespedwards42/collision/blob/master/src/main/java/com/fabahaba/collision/cache/AtomicLogCounters.java).  I think there might be some consistency issues with the acquire/release semantics I'm using through VarHandles though.  I need to go deeper into how that works.  The counters work as expected on my Ubuntu benchmark server, and mac os laptop with Java 9 build 138+.  But the unit test for them is consistently failing on TravisCI's Ubuntu Trusty with build 134.  Waiting for the JDK version to get updated before I look into it further.
  