### PR TITLE
Insert into the hashtable when evicting from Am.

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TwoQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TwoQueuePolicy.java
@@ -176,6 +176,7 @@ public final class TwoQueuePolicy implements Policy {
       data.remove(victim.key);
       victim.remove();
       sizeMain--;
+      data.put(node.key, node);
     }
   }
 


### PR DESCRIPTION
This 2Q implementation was the best I found to evaluate a C based 2Q
implementation that I have been working on.  With this change the
behavior is the same on several workloads at several data-points.

It took a lot of debugging to track this down :-)