### PR TITLE
Fix IllegalStateException being thrown for all event types.

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/event/EventTypeAwareListener.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/event/EventTypeAwareListener.java
@@ -66,16 +66,16 @@ final class EventTypeAwareListener<K, V> implements CacheEntryCreatedListener<K,
       switch (event.getEventType()) {
         case CREATED:
           onCreated(event);
-          break;
+          return;
         case UPDATED:
           onUpdated(event);
-          break;
+          return;
         case REMOVED:
           onRemoved(event);
-          break;
+          return;
         case EXPIRED:
           onExpired(event);
-          break;
+          return;
       }
       throw new IllegalStateException("Unknown event type: " + event.getEventType());
     } catch (Exception e) {


### PR DESCRIPTION
I ran into a problem where an IllegalStateException was being thrown every time my event listeners were invoked.

```
Jul 02, 2017 9:30:20 PM com.github.benmanes.caffeine.jcache.event.EventTypeAwareListener dispatch
WARNING: null
java.lang.IllegalStateException: Unknown event type: REMOVED
	at com.github.benmanes.caffeine.jcache.event.EventTypeAwareListener.dispatch(EventTypeAwareListener.java:80)
	at com.github.benmanes.caffeine.jcache.event.EventDispatcher.lambda$publish$2(EventDispatcher.java:215)
	at java.util.concurrent.CompletableFuture.uniRun(CompletableFuture.java:705)
	at java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:687)
	at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:443)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

I traced it down to what appears to be a missing default case in the EventType switch statement. This patch resolves the issue for me and passes the relevant tests.