### PR TITLE
Allow unwrapping of a JCache cache to a native Caffeine cache

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -887,6 +887,9 @@ public class CacheProxy<K, V> implements Cache<K, V> {
 
   @Override
   public <T> T unwrap(Class<T> clazz) {
+    if (clazz.isAssignableFrom(cache.getClass())) {
+      return clazz.cast(cache);
+    }
     if (clazz.isAssignableFrom(getClass())) {
       return clazz.cast(this);
     }

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/CacheProxyTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/CacheProxyTest.java
@@ -1,0 +1,29 @@
+package com.github.benmanes.caffeine.jcache;
+
+import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
+import org.testng.annotations.Test;
+
+import javax.cache.Cache;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class CacheProxyTest extends AbstractJCacheTest {
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void unwrap_fail() {
+    jcache.unwrap(CaffeineConfiguration.class);
+  }
+
+  @Test
+  public void unwrap() {
+    assertThat(jcache.unwrap(Cache.class), sameInstance(jcache));
+    assertThat(jcache.unwrap(CacheProxy.class), sameInstance(jcache));
+    assertThat(jcache.unwrap(com.github.benmanes.caffeine.cache.Cache.class), sameInstance(jcache.cache));
+  }
+
+  @Override
+  protected CaffeineConfiguration<Integer, Integer> getConfiguration() {
+    return new CaffeineConfiguration<>();
+  }
+}


### PR DESCRIPTION
We are using Caffeine with JCache and need access to the native Caffeine cache to register it with [Prometheus](https://github.com/prometheus/client_java/blob/master/simpleclient_caffeine/src/main/java/io/prometheus/client/cache/caffeine/CacheMetricsCollector.java). The current implementation just returns itself.

This is very similar to the way [Ehcache](https://github.com/ehcache/ehcache-jcache/blob/598c609d3f1d5addcdb866f64b37b9769d2fd97b/ehcache-jcache/src/main/java/org/ehcache/jcache/JCache.java#L726-L732) is doing it.
