### PR TITLE
Allow configuration of max size and expiry simultaneously for JCache

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
@@ -156,9 +156,9 @@ final class CacheFactory {
 
     /** Creates a configured cache. */
     public CacheProxy<K, V> build() {
-      boolean evicts = configureMaximumSize() || configureMaximumWeight()
-          || configureExpireAfterWrite() || configureExpireAfterAccess()
-          || configureExpireVariably();
+      boolean evicts = configureMaximumSize() | configureMaximumWeight()
+          | configureExpireAfterWrite() | configureExpireAfterAccess()
+          | configureExpireVariably();
       if (evicts) {
         configureEvictionListener();
       }

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/expiry/JCacheExpiryAndMaximumSizeTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/expiry/JCacheExpiryAndMaximumSizeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.jcache.expiry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.jcache.AbstractJCacheTest;
+import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.event.CacheEntryRemovedListener;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * The test cases that ensures the <tt>variable expiry</tt> policy and <tt>maximum size</tt> settings
+ * are set simultaneously.
+ *
+ * @author github.com/kdombeck (Ken Dombeck)
+ */
+@Test(singleThreaded = true)
+@SuppressWarnings("unchecked")
+public class JCacheExpiryAndMaximumSizeTest extends AbstractJCacheTest {
+  private static final long ONE_MINUTE = TimeUnit.MINUTES.toNanos(1);
+  private static final int MAXIMUM = 10;
+
+  private Expiry<Integer, Integer> expiry = Mockito.mock(Expiry.class);
+  private final AtomicInteger removed = new AtomicInteger();
+
+  @BeforeMethod
+  public void setup() {
+    Mockito.reset(expiry);
+    when(expiry.expireAfterCreate(anyInt(), anyInt(), anyLong())).thenReturn(ONE_MINUTE);
+    when(expiry.expireAfterUpdate(anyInt(), anyInt(), anyLong(), anyLong())).thenReturn(ONE_MINUTE);
+    when(expiry.expireAfterRead(anyInt(), anyInt(), anyLong(), anyLong())).thenReturn(ONE_MINUTE);
+  }
+
+  @Override
+  protected CaffeineConfiguration<Integer, Integer> getConfiguration() {
+    CacheEntryRemovedListener<Integer, Integer> listener = events -> removed.incrementAndGet();
+
+    CaffeineConfiguration<Integer, Integer> configuration = new CaffeineConfiguration<>();
+
+    configuration.setMaximumSize(OptionalLong.of(MAXIMUM));
+    CacheEntryListenerConfiguration<Integer, Integer> listenerConfiguration =
+        new MutableCacheEntryListenerConfiguration<>(() -> listener,
+            /* filterFactory */ null, /* isOldValueRequired */ false, /* isSynchronous */ true);
+    configuration.addCacheEntryListenerConfiguration(listenerConfiguration);
+    configuration.setExecutorFactory(MoreExecutors::directExecutor);
+
+    configuration.setExpiryFactory(Optional.of(() -> expiry));
+    configuration.setTickerFactory(() -> ticker::read);
+
+    return configuration;
+  }
+
+  @Test
+  public void expiry() {
+    jcache.put(KEY_1, VALUE_1);
+    verify(expiry, times(1)).expireAfterCreate(anyInt(), anyInt(), anyLong());
+
+    jcache.put(KEY_1, VALUE_2);
+    verify(expiry).expireAfterUpdate(anyInt(), anyInt(), anyLong(), anyLong());
+
+    jcache.get(KEY_1);
+    verify(expiry).expireAfterRead(anyInt(), anyInt(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void size() {
+    for (int i = 0; i < 2 * MAXIMUM; i++) {
+      jcache.put(i, i);
+    }
+    assertThat(removed.get(), is(MAXIMUM));
+  }
+}


### PR DESCRIPTION
The ```eager-expiration``` will not take affect with the following configuration 
```
test-cache {
  policy {
    eager-expiration {
      after-write = 10m
    }

    maximum {
      size = 1000
    }
  }
}
```
As you can see by this [code](https://github.com/ben-manes/caffeine/blob/master/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java#L159-L161).
```
      boolean evicts = configureMaximumSize() || configureMaximumWeight()
          || configureExpireAfterWrite() || configureExpireAfterAccess()
          || configureExpireVariably();
```
The first configuration that it finds is the only one that gets configured.

I looked at passing mocks into ```CacheFactory``` but doesn't seem possible since the configuration gets cloned. So please let me know if there is a better way I should be testing this.