### PR TITLE
Compile generated classes withoug debug info

### DIFF
--- a/caffeine/build.gradle
+++ b/caffeine/build.gradle
@@ -8,6 +8,9 @@ sourceSets {
   main {
     java.srcDir "${buildDir}/generated-sources/"
   }
+  gen {
+    java.srcDir "${buildDir}/generated-sources/"
+  }
 }
 
 configurations {
@@ -55,6 +58,14 @@ dependencies {
   javaPoetCompile libraries.commonsLang3
 }
 
+task compileNoDebug(type: JavaCompile) {
+  source = sourceSets.gen.java.srcDirs
+  destinationDir = compileJava.destinationDir
+  options.debug = false
+  options.incremental = false
+  classpath = sourceSets.main.runtimeClasspath
+}
+
 jar.manifest {
   name 'com.github.ben-manes.caffeine'
   instruction 'Import-Package',
@@ -65,6 +76,8 @@ jar.manifest {
     'com.github.benmanes.caffeine.cache',
     'com.github.benmanes.caffeine.cache.stats'
 }
+
+jar.dependsOn(compileNoDebug)
 
 sonarqube {
   properties {


### PR DESCRIPTION
Addressing https://github.com/ben-manes/caffeine/issues/110.
Just by not emitting debug symbols for the generated classes 200k can be saved.
The price to pay is recompiling the generated classes twice.

```
object       | before    | after     | savings (bytes)
------------------------------------------------------
class files  | 2,431,199 | 1,793,522 | 637677
caffeine.jar |   816,949 | 1,009,405 | 192456
```