### PR TITLE
Make a Node a factory for itself

### DIFF
--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/Specifications.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/Specifications.java
@@ -15,10 +15,6 @@
  */
 package com.github.benmanes.caffeine.cache;
 
-import java.lang.ref.ReferenceQueue;
-
-import javax.lang.model.element.Modifier;
-
 import com.google.common.base.CaseFormat;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
@@ -26,6 +22,9 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
+
+import javax.lang.model.element.Modifier;
+import java.lang.ref.ReferenceQueue;
 
 /**
  * Shared constants for a code generation specification.
@@ -40,35 +39,51 @@ public final class Specifications {
   public static final String DEAD_WEAK_KEY = "DEAD_WEAK_KEY";
 
   public static final TypeVariableName kTypeVar = TypeVariableName.get("K");
+  public static final TypeVariableName kTypeVar2 = TypeVariableName.get("K2");
   public static final TypeVariableName vTypeVar = TypeVariableName.get("V");
+  public static final TypeVariableName vTypeVar2 = TypeVariableName.get("V2");
   public static final TypeName kRefQueueType = ParameterizedTypeName.get(
       ClassName.get(ReferenceQueue.class), kTypeVar);
+  public static final TypeName kRefQueueType2 = ParameterizedTypeName.get(
+          ClassName.get(ReferenceQueue.class), kTypeVar2);
   public static final TypeName vRefQueueType = ParameterizedTypeName.get(
       ClassName.get(ReferenceQueue.class), vTypeVar);
+  public static final TypeName vRefQueueType2 = ParameterizedTypeName.get(
+          ClassName.get(ReferenceQueue.class), vTypeVar2);
   public static final ClassName nodeType = ClassName.get(PACKAGE_NAME, "Node");
   public static final TypeName lookupKeyType = ParameterizedTypeName.get(ClassName.get(
       PACKAGE_NAME + ".References", "LookupKeyReference"), kTypeVar);
+  public static final TypeName lookupKeyType2 = ParameterizedTypeName.get(ClassName.get(
+          PACKAGE_NAME + ".References", "LookupKeyReference"), kTypeVar2);
   public static final TypeName referenceKeyType = ParameterizedTypeName.get(
       ClassName.get(PACKAGE_NAME + ".References", "WeakKeyReference"), kTypeVar);
+  public static final TypeName referenceKeyType2 = ParameterizedTypeName.get(
+          ClassName.get(PACKAGE_NAME + ".References", "WeakKeyReference"), kTypeVar2);
   public static final TypeName rawReferenceKeyType = ParameterizedTypeName.get(
       ClassName.get(PACKAGE_NAME + ".References", "WeakKeyReference"), ClassName.get(Object.class));
 
   public static final ParameterSpec keySpec = ParameterSpec.builder(kTypeVar, "key").build();
+  public static final ParameterSpec keySpec2 = ParameterSpec.builder(kTypeVar2, "key").build();
   public static final ParameterSpec keyRefSpec =
       ParameterSpec.builder(Object.class, "keyReference").build();
   public static final ParameterSpec keyRefQueueSpec =
       ParameterSpec.builder(kRefQueueType, "keyReferenceQueue").build();
-
+  public static final ParameterSpec keyRefQueueSpec2 =
+          ParameterSpec.builder(kRefQueueType2, "keyReferenceQueue").build();
   public static final ParameterSpec valueSpec = ParameterSpec.builder(vTypeVar, "value").build();
+  public static final ParameterSpec valueSpec2 = ParameterSpec.builder(vTypeVar2, "value").build();
   public static final ParameterSpec valueRefQueueSpec =
       ParameterSpec.builder(vRefQueueType, "valueReferenceQueue").build();
-
+  public static final ParameterSpec valueRefQueueSpec2 =
+          ParameterSpec.builder(vRefQueueType2, "valueReferenceQueue").build();
   public static final TypeName NODE = ParameterizedTypeName.get(nodeType, kTypeVar, vTypeVar);
+  public static final TypeName NODE2 = ParameterizedTypeName.get(nodeType, kTypeVar2, vTypeVar2);
   public static final TypeName UNSAFE_ACCESS =
       ClassName.get("com.github.benmanes.caffeine.base", "UnsafeAccess");
   public static final TypeName LOCAL_CACHE_FACTORY =
       ClassName.get(PACKAGE_NAME, "LocalCacheFactory");
-
+  public static final TypeName NODE_FACTORY =
+          ClassName.get(PACKAGE_NAME, "NodeFactory");
   public static final ClassName BUILDER = ClassName.get(PACKAGE_NAME, "Caffeine");
   public static final ParameterSpec BUILDER_PARAM = ParameterSpec.builder(ParameterizedTypeName.get(
       BUILDER, kTypeVar, vTypeVar), "builder").build();

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddConstructors.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddConstructors.java
@@ -40,8 +40,14 @@ public final class AddConstructors extends NodeRule {
 
   @Override
   protected void execute() {
+    addConstructorDefault();
     addConstructorByKey();
     addConstructorByKeyRef();
+  }
+
+  /** Adds the constructor used to create a factory. */
+  private void addConstructorDefault() {
+    context.constructorDefault = MethodSpec.constructorBuilder();
   }
 
   /** Adds the constructor by key to the node type. */

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddFactoryMethods.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddFactoryMethods.java
@@ -1,0 +1,121 @@
+package com.github.benmanes.caffeine.cache.node;
+
+import com.github.benmanes.caffeine.cache.Feature;
+import com.squareup.javapoet.MethodSpec;
+
+import javax.lang.model.element.Modifier;
+
+import static com.github.benmanes.caffeine.cache.Specifications.NODE2;
+import static com.github.benmanes.caffeine.cache.Specifications.kRefQueueType2;
+import static com.github.benmanes.caffeine.cache.Specifications.kTypeVar2;
+import static com.github.benmanes.caffeine.cache.Specifications.keyRefQueueSpec2;
+import static com.github.benmanes.caffeine.cache.Specifications.keyRefSpec;
+import static com.github.benmanes.caffeine.cache.Specifications.keySpec2;
+import static com.github.benmanes.caffeine.cache.Specifications.lookupKeyType2;
+import static com.github.benmanes.caffeine.cache.Specifications.referenceKeyType2;
+import static com.github.benmanes.caffeine.cache.Specifications.vTypeVar2;
+import static com.github.benmanes.caffeine.cache.Specifications.valueRefQueueSpec2;
+import static com.github.benmanes.caffeine.cache.Specifications.valueSpec2;
+
+public class AddFactoryMethods extends NodeRule {
+  @Override
+  protected boolean applies() {
+    return true;
+  }
+
+  @Override
+  protected void execute() {
+    String statementWithKey = makeFactoryStatementKey();
+    String statementWithKeyRef = makeFactoryStatementKeyRef();
+    Object className = context.className;
+
+    context.nodeSubtype
+        .addMethod(newNodeByKey()
+            .addStatement(statementWithKey, className).build())
+        .addMethod(newNodeByKeyRef()
+            .addStatement(statementWithKeyRef, className).build());
+
+    if (context.generateFeatures.contains(Feature.WEAK_KEYS)) {
+      context.nodeSubtype
+          .addMethod(makeNewLookupKey())
+          .addMethod(makeReferenceKey());
+    }
+    if (context.generateFeatures.contains(Feature.WEAK_VALUES)) {
+      context.nodeSubtype
+          .addMethod(makeWeakValues());
+    }
+    if (context.generateFeatures.contains(Feature.SOFT_VALUES)) {
+      context.nodeSubtype
+          .addMethod(makeSoftValues());
+    }
+  }
+
+  private MethodSpec makeSoftValues() {
+    return MethodSpec.methodBuilder("softValues")
+        .addModifiers(Modifier.PUBLIC)
+        .addStatement("return true")
+        .returns(boolean.class)
+        .build();
+  }
+
+  private MethodSpec makeWeakValues() {
+    return MethodSpec.methodBuilder("weakValues")
+        .addModifiers(Modifier.PUBLIC)
+        .addStatement("return true")
+        .returns(boolean.class)
+        .build();
+  }
+
+  private MethodSpec makeNewLookupKey() {
+    return MethodSpec.methodBuilder("newLookupKey")
+        .addModifiers(Modifier.PUBLIC)
+        .addTypeVariable(kTypeVar2)
+        .addParameter(kTypeVar2, "key")
+        .addStatement("return new $T(key)", lookupKeyType2)
+        .returns(Object.class)
+        .build();
+  }
+
+  private MethodSpec.Builder newNodeByKey() {
+    return completeNewNode(MethodSpec.methodBuilder("newNode")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(keySpec2)
+            .addParameter(keyRefQueueSpec2));
+  }
+
+  private MethodSpec.Builder newNodeByKeyRef() {
+    return completeNewNode(MethodSpec.methodBuilder("newNode")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(keyRefSpec));
+  }
+
+  private static MethodSpec.Builder completeNewNode(MethodSpec.Builder method) {
+    return method
+            .addTypeVariable(kTypeVar2)
+            .addTypeVariable(vTypeVar2)
+            .addParameter(valueSpec2)
+            .addParameter(valueRefQueueSpec2)
+            .addParameter(int.class, "weight")
+            .addParameter(long.class, "now")
+            .returns(NODE2);
+  }
+
+  private MethodSpec makeReferenceKey() {
+    return MethodSpec.methodBuilder("newReferenceKey")
+        .addModifiers(Modifier.PUBLIC)
+        .addTypeVariable(kTypeVar2)
+        .addParameter(kTypeVar2, "key")
+        .addParameter(kRefQueueType2, "referenceQueue")
+        .addStatement("return new $T($L, $L)", referenceKeyType2, "key", "referenceQueue")
+        .returns(Object.class)
+        .build();
+  }
+
+  private String makeFactoryStatementKey() {
+    return "return new $N<>(key, keyReferenceQueue, value, valueReferenceQueue, weight, now)";
+  }
+
+  private String makeFactoryStatementKeyRef() {
+    return "return new $N<>(keyReference, value, valueReferenceQueue, weight, now)";
+  }
+}

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddSubtype.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddSubtype.java
@@ -21,6 +21,7 @@ import static com.github.benmanes.caffeine.cache.Specifications.vTypeVar;
 
 import javax.lang.model.element.Modifier;
 
+import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 
@@ -39,15 +40,16 @@ public final class AddSubtype extends NodeRule {
   @Override
   protected void execute() {
     context.nodeSubtype = TypeSpec.classBuilder(context.className)
-        .addModifiers(Modifier.STATIC)
+        .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
         .addTypeVariable(kTypeVar)
         .addTypeVariable(vTypeVar);
     if (context.isFinal) {
       context.nodeSubtype.addModifiers(Modifier.FINAL);
     }
     if (isBaseClass()) {
-      context.nodeSubtype.addSuperinterface(
-          ParameterizedTypeName.get(nodeType, kTypeVar, vTypeVar));
+      context.nodeSubtype
+              .addSuperinterface(ParameterizedTypeName.get(nodeType, kTypeVar, vTypeVar))
+              .addSuperinterface(ClassName.get("com.github.benmanes.caffeine.cache", "NodeFactory"));
     } else {
       context.nodeSubtype.superclass(context.superClass);
     }

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/Finalize.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/Finalize.java
@@ -30,6 +30,7 @@ public class Finalize extends NodeRule {
   @Override
   protected void execute() {
     context.nodeSubtype
+        .addMethod(context.constructorDefault.build())
         .addMethod(context.constructorByKey.build())
         .addMethod(context.constructorByKeyRef.build());
   }

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/NodeContext.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/NodeContext.java
@@ -37,8 +37,9 @@ public final class NodeContext {
   public TypeSpec.Builder nodeSubtype;
   public MethodSpec.Builder constructorByKey;
   public MethodSpec.Builder constructorByKeyRef;
+  public MethodSpec. Builder constructorDefault;
 
-  public NodeContext(TypeName superClass, String className, boolean isFinal,
+    public NodeContext(TypeName superClass, String className, boolean isFinal,
       Set<Feature> parentFeatures, Set<Feature> generateFeatures) {
     this.isFinal = isFinal;
     this.className = requireNonNull(className);

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/IsCacheReserializable.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/IsCacheReserializable.java
@@ -19,14 +19,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
 import com.github.benmanes.caffeine.cache.Async.AsyncExpiry;
 import com.github.benmanes.caffeine.cache.Async.AsyncWeigher;
 import com.github.benmanes.caffeine.testing.DescriptionBuilder;
 import com.google.common.testing.SerializableTester;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that evaluates a cache by creating a serialized copy and checking its equality.
@@ -212,7 +212,7 @@ public final class IsCacheReserializable<T> extends TypeSafeDiagnosingMatcher<T>
     desc.expectThat("empty", copy.estimatedSize(), is(0L));
     desc.expectThat("same weigher", unwrapWeigher(copy.weigher).getClass(),
         is(equalTo(unwrapWeigher(original.weigher).getClass())));
-    desc.expectThat("same nodeFactory", copy.nodeFactory, is(original.nodeFactory));
+    desc.expectThat("same nodeFactory", copy.nodeFactory, sameClass(original.nodeFactory));
     if (original.evicts()) {
       desc.expectThat("same maximumWeight", copy.maximum(), is(original.maximum()));
       desc.expectThat("same maximumEdenWeight", copy.edenMaximum(), is(original.edenMaximum()));
@@ -253,6 +253,20 @@ public final class IsCacheReserializable<T> extends TypeSafeDiagnosingMatcher<T>
     } else if (copy.removalListener().getClass() != original.removalListener().getClass()) {
       desc.expected("same removalListener but was " + copy.removalListener().getClass());
     }
+  }
+
+  private static Matcher<Object> sameClass(Object expected) {
+    return new BaseMatcher<Object>() {
+      @Override
+      public boolean matches(Object item) {
+        return expected.getClass() == item.getClass();
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Classes are different");
+      }
+    };
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
How about this: make the node class a factory for itself :) (details in the commit message)

Zero reflection on the fast path + 90KB classes less.

It is not how a real gentleman would structure their Java code but the circumstances are extreme :)