### PR TITLE
JCache Cache.invoke does not update entry after initial load

### DIFF
--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/processor/EntryProcessorTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/processor/EntryProcessorTest.java
@@ -50,11 +50,13 @@ public final class EntryProcessorTest extends AbstractJCacheTest {
   private final Map<Integer, Integer> map = new HashMap<>();
 
   private int loads;
+  private int writes;
 
   @BeforeMethod
   public void beforeMethod() {
     map.clear();
     loads = 0;
+    writes = 0;
   }
 
   @Override
@@ -90,6 +92,14 @@ public final class EntryProcessorTest extends AbstractJCacheTest {
     assertThat(loads, is(2));
   }
 
+  @Test
+  public void writeOccursForInitialLoadOfEntry() {
+    map.put(KEY_1, 100);
+    jcache.invoke(KEY_1, this::process);
+    assertThat(loads, is(1));
+    assertThat(writes, is(1));
+  }
+
   private Object process(MutableEntry<Integer, Integer> entry, Object... arguments) {
     Integer value = MoreObjects.firstNonNull(entry.getValue(), 0);
     entry.setValue(++value);
@@ -100,6 +110,7 @@ public final class EntryProcessorTest extends AbstractJCacheTest {
 
     @Override
     public void write(Entry<? extends Integer, ? extends Integer> entry) {
+      writes++;
       map.put(entry.getKey(), entry.getValue());
     }
 


### PR DESCRIPTION
If the cache is empty and you call ```jcache.invoke(key, entryProcessor)``` it will load the cache with the cache loader but then it will not write the updated entry with the cache writer. The reason is because the ```EntryProcessorEntry.action``` is LOADED rather than UPDATED.

Possibly related to https://github.com/ben-manes/caffeine/issues/187.

This is currently just a unit test showing the problem, it does not contain a fix. I'm not sure which direction to go for a possible fix.