### PR TITLE
Enable configuring the window cache size via policy/eviction

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -453,6 +453,8 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef<K, V>
   @GuardedBy("evictionLock")
   void setMaximum(long maximum, double mainPercentage) {
     requireArgument(maximum >= 0);
+    requireArgument(mainPercentage >= 0);
+    requireArgument(mainPercentage <= 1.0d);
 
     long max = Math.min(maximum, MAXIMUM_CAPACITY);
     long eden = max - (long) (max * mainPercentage);
@@ -3173,7 +3175,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef<K, V>
       @Override public void setMaximum(long maximum, double percentMain) {
         cache.evictionLock.lock();
         try {
-          cache.setMaximum(maximum);
+          cache.setMaximum(maximum, percentMain);
           cache.maintenance(/* ignored */ null);
         } finally {
           cache.evictionLock.unlock();

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -441,14 +441,14 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef<K, V>
    * to eagerly evicts entries until the cache shrinks to the appropriate size.
    */
   @GuardedBy("evictionLock")
-  void setMaximum(long maximum){
+  void setMaximum(long maximum) {
       setMaximum(maximum, PERCENT_MAIN);
   }
 
   /**
-   * Sets the maximum weighted size of the cache and the ration between eden and LFU.
-   *  The caller may need to perform a maintenance cycle
-   * to eagerly evicts entries until the cache shrinks to the appropriate size.
+   * Sets the maximum weighted size of the cache and the ratio between eden and LFU.
+   * The caller may need to perform a maintenance cycle to eagerly evicts entries until
+   * the cache shrinks to the appropriate size.
    */
   @GuardedBy("evictionLock")
   void setMaximum(long maximum, double mainPercentage) {
@@ -3166,7 +3166,10 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef<K, V>
       @Override public long getMaximum() {
         return cache.maximum();
       }
-      @Override public void setMaximum(long maximum){ setMaximum(maximum, PERCENT_MAIN);}
+      @Override public void setMaximum(long maximum)
+      {
+        setMaximum(maximum, PERCENT_MAIN);
+      }
       @Override public void setMaximum(long maximum, double percentMain) {
         cache.evictionLock.lock();
         try {

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -3168,8 +3168,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef<K, V>
       @Override public long getMaximum() {
         return cache.maximum();
       }
-      @Override public void setMaximum(long maximum)
-      {
+      @Override public void setMaximum(long maximum) {
         setMaximum(maximum, PERCENT_MAIN);
       }
       @Override public void setMaximum(long maximum, double percentMain) {

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
@@ -168,6 +168,25 @@ public interface Policy<K, V> {
     void setMaximum(@NonNegative long maximum);
 
     /**
+     * Specifies the maximum total size of this cache. This value may be interpreted as the weighted
+     * or unweighted threshold size based on how this cache was constructed. If the cache currently
+     * exceeds the new maximum size this operation eagerly evict entries until the cache shrinks to
+     * the appropriate size.
+     * <p>
+     * This version also sets the ratio between LRU eden and the LFU cache
+     * <p>
+     * Note that some implementations may have an internal inherent bound on the maximum total size.
+     * If the value specified exceeds that bound, then the value is set to the internal maximum.
+     *
+     * @param maximum the maximum, interpreted as weighted or unweighted size depending on how this
+     *        cache was constructed
+     * @param percentMain relative size of the main (LFU) cache as percentage (0 &lt; percentMain &lt; 1)
+     * @throws IllegalArgumentException if the maximum size specified is negative
+     */
+    void setMaximum(@NonNegative long maximum, double percentMain);
+
+
+    /**
      * Returns an unmodifiable snapshot {@link Map} view of the cache with ordered traversal. The
      * order of iteration is from the entries least likely to be retained (coldest) to the entries
      * most likely to be retained (hottest). This order is determined by the eviction policy's best

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
@@ -186,7 +186,6 @@ public interface Policy<K, V> {
      */
     void setMaximum(@NonNegative long maximum, double percentMain);
 
-
     /**
      * Returns an unmodifiable snapshot {@link Map} view of the cache with ordered traversal. The
      * order of iteration is from the entries least likely to be retained (coldest) to the entries

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
@@ -180,7 +180,7 @@ public interface Policy<K, V> {
      *
      * @param maximum the maximum, interpreted as weighted or unweighted size depending on how this
      *        cache was constructed
-     * @param percentMain relative size of the main (LFU) cache as percentage (0 &le; percentMain &le; 1)
+     * @param percentMain relative size of the main (LFU) cache as percentage of maximum (0 &le; percentMain &le; 1)
      * @throws IllegalArgumentException if the maximum size specified is negative or percentMain is less
      *        than 0 or greater than 1
      */

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
@@ -180,7 +180,7 @@ public interface Policy<K, V> {
      *
      * @param maximum the maximum, interpreted as weighted or unweighted size depending on how this
      *        cache was constructed
-     * @param percentMain relative size of the main (LFU) cache as percentage (0 &lt; percentMain &lt; 1)
+     * @param percentMain relative size of the main (LFU) cache as percentage (0 &le; percentMain &le; 1)
      * @throws IllegalArgumentException if the maximum size specified is negative
      */
     void setMaximum(@NonNegative long maximum, double percentMain);

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
@@ -181,7 +181,8 @@ public interface Policy<K, V> {
      * @param maximum the maximum, interpreted as weighted or unweighted size depending on how this
      *        cache was constructed
      * @param percentMain relative size of the main (LFU) cache as percentage (0 &le; percentMain &le; 1)
-     * @throws IllegalArgumentException if the maximum size specified is negative
+     * @throws IllegalArgumentException if the maximum size specified is negative or percentMain is less
+     *        than 0 or greater than 1
      */
     void setMaximum(@NonNegative long maximum, double percentMain);
 

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -1,0 +1,19 @@
+package com.github.benmanes.caffeine.cache;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestEdenResize {
+    @Test
+    public void TestResizingEden(){
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1024).build();
+        cache.put(1,1);
+        Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().orElse(null);
+        Assert.assertNotNull(eviction);
+        Assert.assertNotNull(cache.getIfPresent(1));
+        if (eviction != null){
+            eviction.setMaximum(eviction.getMaximum(), .5d);
+        }
+        Assert.assertNotNull(cache.getIfPresent(1));
+    }
+}

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -5,13 +5,13 @@ import org.junit.Test;
 
 public class TestEdenResize {
     @Test
-    public void TestResizingEden(){
+    public void TestResizingEden() {
         Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1024).build();
-        cache.put(1,1);
+        cache.put(1, 1);
         Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().orElse(null);
         Assert.assertNotNull(eviction);
         Assert.assertNotNull(cache.getIfPresent(1));
-        if (eviction != null){
+        if (eviction != null) {
             eviction.setMaximum(eviction.getMaximum(), .5d);
         }
         Assert.assertNotNull(cache.getIfPresent(1));

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -1,5 +1,7 @@
 package com.github.benmanes.caffeine.cache;
 
+import com.github.benmanes.caffeine.cache.testing.CacheSpec;
+import org.ehcache.impl.internal.executor.ExecutorUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,15 +45,12 @@ public class TestEdenResize {
 
     @Test
     public void Test100PercentWindow() throws InterruptedException {
-        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).build();
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).executor(CacheSpec.CacheExecutor.DIRECT.create()).build();
         Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().get();
         eviction.setMaximum(eviction.getMaximum(), 0d);
         for (int counter = 0; counter < 2000; ++counter) {
             cache.put(counter, counter);
         }
-
-        // need to wait for a moment to give the cache time to evict stuff.
-        sleep(1000);
 
         // if the window is 100% of the cache, the last 1000 entries should be in the cache. There can be a  temporary
         // overhang containing arbitrary older keys.
@@ -65,15 +64,12 @@ public class TestEdenResize {
 
     @Test
     public void Test50PercentWindow() throws InterruptedException {
-        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).build();
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).executor(CacheSpec.CacheExecutor.DIRECT.create()).build();
         Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().get();
         eviction.setMaximum(eviction.getMaximum(), .5d);
         for (int counter = 0; counter < 2000; ++counter) {
             cache.put(counter, counter);
         }
-
-        // need to wait for a moment to give the cache time to evict stuff.
-        sleep(1000);
 
         // if the window is 50% of the cache, the last 500 entries should be in the cache.
         Map<Integer, Integer> cm = cache.asMap();

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -45,18 +45,16 @@ public class TestEdenResize {
 
     @Test
     public void Test100PercentWindow() throws InterruptedException {
-        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).executor(CacheSpec.CacheExecutor.DIRECT.create()).build();
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(10).executor(CacheSpec.CacheExecutor.DIRECT.create()).build();
         Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().get();
         eviction.setMaximum(eviction.getMaximum(), 0d);
-        for (int counter = 0; counter < 2000; ++counter) {
+        for (int counter = 0; counter < 20; ++counter) {
             cache.put(counter, counter);
         }
 
-        // if the window is 100% of the cache, the last 1000 entries should be in the cache. There can be a  temporary
-        // overhang containing arbitrary older keys.
-        // however, it turns out that about 10% are still older keys
+        // if the window is 100% of the cache, the last 10 entries should be in the cache.
         Map<Integer, Integer> cm = cache.asMap();
-        for (int counter = 1200; counter < 2000; ++counter) {
+        for (int counter = 10; counter < 20; ++counter) {
             Integer val = cache.getIfPresent(counter);
             Assert.assertNotNull(String.format("Failed to find key %d", counter), val);
         }
@@ -64,22 +62,22 @@ public class TestEdenResize {
 
     @Test
     public void Test50PercentWindow() throws InterruptedException {
-        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).executor(CacheSpec.CacheExecutor.DIRECT.create()).build();
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(10).executor(CacheSpec.CacheExecutor.DIRECT.create()).build();
         Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().get();
         eviction.setMaximum(eviction.getMaximum(), .5d);
-        for (int counter = 0; counter < 2000; ++counter) {
+        for (int counter = 0; counter < 20; ++counter) {
             cache.put(counter, counter);
         }
 
         // if the window is 50% of the cache, the last 500 entries should be in the cache.
         Map<Integer, Integer> cm = cache.asMap();
-        for (int counter = 1500; counter < 2000; ++counter) {
+        for (int counter = 15; counter < 20; ++counter) {
             Assert.assertTrue(cm.keySet().contains(counter));
         }
 
         // some keys between 1000 and 1500 will be missing because they didn't make it to the main cache
         boolean missing = false;
-        for (int counter = 1000; counter < 1500; ++counter) {
+        for (int counter = 10; counter < 15; ++counter) {
             if (!cm.keySet().contains(counter)) {
                 missing = true;
             }

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -3,17 +3,94 @@ package com.github.benmanes.caffeine.cache;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.Console;
+import java.util.Map;
+
+import static java.lang.Thread.sleep;
+
 public class TestEdenResize {
     @Test
     public void TestResizingEden() {
         Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1024).build();
         cache.put(1, 1);
         Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().orElse(null);
-        Assert.assertNotNull(eviction);
         Assert.assertNotNull(cache.getIfPresent(1));
-        if (eviction != null) {
-            eviction.setMaximum(eviction.getMaximum(), .5d);
-        }
+        Assert.assertTrue("Failed to set percentMain to 0.5", cleanlySetPercentMain(eviction, 0.5d));
+        Assert.assertNotNull(cache.getIfPresent(1));
+        Assert.assertTrue("Failed to set percentMain to 0", cleanlySetPercentMain(eviction, 0d));
+        Assert.assertNotNull(cache.getIfPresent(1));
+        Assert.assertTrue("Failed to set percentMain to 1", cleanlySetPercentMain(eviction, 1d));
         Assert.assertNotNull(cache.getIfPresent(1));
     }
+
+    private boolean cleanlySetPercentMain(Policy.Eviction<Integer, Integer> eviction, double percentMain) {
+        Assert.assertNotNull(eviction);
+        try {
+            eviction.setMaximum(eviction.getMaximum(), percentMain);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Test
+    public void TestPercentageMainOutOfBounds() {
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1024).build();
+        Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().orElse(null);
+        Assert.assertFalse("Failed to throw for percentMain < 0", cleanlySetPercentMain(eviction, -1d));
+        Assert.assertFalse("Failed to throw for percentMain > 1", cleanlySetPercentMain(eviction, 1.01d));
+    }
+
+    @Test
+    public void Test100PercentWindow() throws InterruptedException {
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).build();
+        Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().get();
+        eviction.setMaximum(eviction.getMaximum(), 0d);
+        for (int counter = 0; counter < 2000; ++counter) {
+            cache.put(counter, counter);
+        }
+
+        // need to wait for a moment to give the cache time to evict stuff.
+        sleep(1000);
+
+        // if the window is 100% of the cache, the last 1000 entries should be in the cache. There can be a  temporary
+        // overhang containing arbitrary older keys.
+        // however, it turns out that about 10% are still older keys
+        Map<Integer, Integer> cm = cache.asMap();
+        for (int counter = 1200; counter < 2000; ++counter) {
+            Integer val = cache.getIfPresent(counter);
+            Assert.assertNotNull(String.format("Failed to find key %d", counter), val);
+        }
+    }
+
+    @Test
+    public void Test50PercentWindow() throws InterruptedException {
+        Cache<Integer, Integer> cache = Caffeine.newBuilder().maximumSize(1000).build();
+        Policy.Eviction<Integer, Integer> eviction = cache.policy().eviction().get();
+        eviction.setMaximum(eviction.getMaximum(), .5d);
+        for (int counter = 0; counter < 2000; ++counter) {
+            cache.put(counter, counter);
+        }
+
+
+        // need to wait for a moment to give the cache time to evict stuff.
+        sleep(1000);
+
+        // if the window is 50% of the cache, the last 500 entries should be in the cache.
+        Map<Integer, Integer> cm = cache.asMap();
+        for (int counter = 1500; counter < 2000; ++counter) {
+            Assert.assertTrue(cm.keySet().contains(counter));
+        }
+
+        // some keys between 1000 and 1500 will be missing because they didn't make it to the main cache
+        boolean missing = false;
+        for (int counter = 1000; counter < 1500; ++counter) {
+            if (!cm.keySet().contains(counter)) {
+                missing = true;
+            }
+        }
+        Assert.assertTrue("All keys made it to the main cache!", missing);
+    }
+
+
 }

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -3,6 +3,7 @@ package com.github.benmanes.caffeine.cache;
 import com.github.benmanes.caffeine.cache.testing.CacheSpec;
 import org.junit.Assert;
 import org.junit.Test;
+
 import java.util.Map;
 
 public class TestEdenResize {
@@ -64,13 +65,13 @@ public class TestEdenResize {
             cache.put(counter, counter);
         }
 
-        // if the window is 50% of the cache, the last 500 entries should be in the cache.
+        // if the window is 50% of the cache, the last 5 entries should be in the cache.
         Map<Integer, Integer> cm = cache.asMap();
         for (int counter = 15; counter < 20; ++counter) {
             Assert.assertTrue(cm.keySet().contains(counter));
         }
 
-        // some keys between 1000 and 1500 will be missing because they didn't make it to the main cache
+        // some keys between 10 and 15 will be missing because they didn't make it to the main cache
         boolean missing = false;
         for (int counter = 10; counter < 15; ++counter) {
             if (!cm.keySet().contains(counter)) {

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -72,7 +72,6 @@ public class TestEdenResize {
             cache.put(counter, counter);
         }
 
-
         // need to wait for a moment to give the cache time to evict stuff.
         sleep(1000);
 
@@ -91,6 +90,4 @@ public class TestEdenResize {
         }
         Assert.assertTrue("All keys made it to the main cache!", missing);
     }
-
-
 }

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/TestEdenResize.java
@@ -1,14 +1,9 @@
 package com.github.benmanes.caffeine.cache;
 
 import com.github.benmanes.caffeine.cache.testing.CacheSpec;
-import org.ehcache.impl.internal.executor.ExecutorUtil;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.Console;
 import java.util.Map;
-
-import static java.lang.Thread.sleep;
 
 public class TestEdenResize {
     @Test


### PR DESCRIPTION
Adding a low-level method to the `Eviction` interface that allows resetting the window/main percentage on an already created cache. The default behaviour/builder stays exactly the same, but it will be possible to reconfigure the cache ratio.