### PR TITLE
Blocked Bloom filter (faster than regular Bloom; fpp fixed at around 1%)

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/membership/FilterType.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/membership/FilterType.java
@@ -15,6 +15,7 @@
  */
 package com.github.benmanes.caffeine.cache.simulator.membership;
 
+import com.github.benmanes.caffeine.cache.simulator.membership.bloom.BlockedBloom;
 import com.github.benmanes.caffeine.cache.simulator.membership.bloom.BloomFilter;
 import com.github.benmanes.caffeine.cache.simulator.membership.bloom.GuavaBloomFilter;
 
@@ -39,7 +40,16 @@ public enum FilterType {
     @Override public String toString() {
       return "Guava";
     }
-  };
+  },
+  BLOCKED_BLOOM {
+      @Override public Membership create(long expectedInsertions, double fpp) {
+        return new BlockedBloom(expectedInsertions, fpp);
+      }
+      @Override public String toString() {
+        return "BlockedBloom";
+      }
+    };
+  
 
   /**
    * Returns a new membership filter.

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/membership/bloom/BlockedBloom.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/membership/bloom/BlockedBloom.java
@@ -1,0 +1,57 @@
+package com.github.benmanes.caffeine.cache.simulator.membership.bloom;
+
+import java.util.Arrays;
+
+import com.github.benmanes.caffeine.cache.simulator.membership.Membership;
+
+public class BlockedBloom implements Membership {
+
+    private final int buckets;
+    private final long seed;
+    private final long[] data;
+
+    public BlockedBloom(long expectedInsertions, double fpp) {
+        // the fpp parameter is ignored; fpp is about 1%
+        int bitsPerKey = 11;
+        long entryCount = (int) Math.max(1, expectedInsertions);
+        this.seed = Hash.randomSeed();
+        long bits = entryCount * bitsPerKey;
+        if ((bits / 64) + 16 >= Integer.MAX_VALUE) {
+            // an alternative is: use a smaller array, and let the fpp increase
+            // (use an overfull filter)
+            throw new IllegalArgumentException("Max capacity exceeded: " + expectedInsertions);
+        }
+        this.buckets = (int) (bits / 64);
+        data = new long[(int) (buckets + 16)];
+    }
+
+    @Override
+    public boolean mightContain(long key) {
+        long hash = Hash.hash64(key, seed);
+        int start = Hash.reduce((int) hash, buckets);
+        hash = hash ^ Long.rotateLeft(hash, 32);
+        long a = data[start];
+        long b = data[start + 1 + (int) (hash >>> 60)];
+        long m1 = (1L << hash) | (1L << (hash >> 6));
+        long m2 = (1L << (hash >> 12)) | (1L << (hash >> 18));
+        return ((m1 & a) == m1) && ((m2 & b) == m2);
+    }
+
+    @Override
+    public boolean put(long key) {
+        long hash = Hash.hash64(key, seed);
+        int start = Hash.reduce((int) hash, buckets);
+        hash = hash ^ Long.rotateLeft(hash, 32);
+        long m1 = (1L << hash) | (1L << (hash >> 6));
+        long m2 = (1L << (hash >> 12)) | (1L << (hash >> 18));
+        data[start] |= m1;
+        data[start + 1] |= m2;
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(data, 0);
+    }
+
+}

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/membership/bloom/Hash.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/membership/bloom/Hash.java
@@ -1,0 +1,38 @@
+package com.github.benmanes.caffeine.cache.simulator.membership.bloom;
+
+import java.util.Random;
+
+public class Hash {
+
+    private static Random random = new Random();
+
+    public static void setSeed(long seed) {
+        random.setSeed(seed);
+    }
+
+    public static long hash64(long x, long seed) {
+        x += seed;
+        x = (x ^ (x >>> 33)) * 0xff51afd7ed558ccdL;
+        x = (x ^ (x >>> 23)) * 0xc4ceb9fe1a85ec53L;
+        x = x ^ (x >>> 33);
+        return x;
+    }
+
+    public static long randomSeed() {
+        return random.nextLong();
+    }
+
+    /**
+     * Shrink the hash to a value 0..n. Kind of like modulo, but using
+     * multiplication and shift, which are faster to compute.
+     *
+     * @param hash the hash
+     * @param n the maximum of the result
+     * @return the reduced value
+     */
+    public static int reduce(int hash, int n) {
+        // http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+        return (int) (((hash & 0xffffffffL) * n) >>> 32);
+    }
+
+}


### PR DESCRIPTION
This filter should be fast than a regular Bloom filter. I think you use a fpp of 0.1, that is 10%. That's unusually high for a Bloom filter... I'm afraid I don't understand this part. My BlockedBloom uses 0.01 (1%). Sure, I can make a 10% fpp filter, but I'm I would like to understand the reason to use 10%.

I'm afraid I don't know how to test it, even running the existing ones doesn't work for me:

    ./gradlew simulator:run

> Task :simulator:run
[ERROR] [05/10/2019 16:05:20.380] [Main-akka.actor.default-dispatcher-2] [akka.actor.ActorSystemImpl(Main)] 
java.lang.NumberFormatException: For input string: "version https://git-lfs.github.com/spec/v1"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:589)
        at java.lang.Long.parseLong(Long.java:631)
        at java.util.stream.ReferencePipeline$5$1.accept(ReferencePipeline.java:227)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1812)
        at java.util.stream.StreamSpliterators$LongWrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:405)
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:161)
        at java.util.stream.StreamSpliterators$LongWrappingSpliterator.tryAdvance(StreamSpliterators.java:416)
        at java.util.stream.StreamSpliterators$LongWrappingSpliterator.tryAdvance(StreamSpliterators.java:379)
        at java.util.stream.Streams$ConcatSpliterator$OfPrimitive.tryAdvance(Streams.java:799)
        at java.util.stream.Streams$ConcatSpliterator$OfLong.tryAdvance(Streams.java:823)
        at java.util.Spliterators$3Adapter.hasNext(Spliterators.java:771)
        at com.github.benmanes.caffeine.cache.simulator.Simulator.broadcast(Simulator.java:105)
