### PR TITLE
Nit: Update the Javadocs of `refreshAfterWrite` to reflect the actual beha…

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
@@ -740,7 +740,7 @@ public final class Caffeine<K, V> {
    * @param duration the length of time after an entry is created that it should be considered
    *     stale, and thus eligible for refresh
    * @return this {@code Caffeine} instance (for chaining)
-   * @throws IllegalArgumentException if {@code duration} is negative
+   * @throws IllegalArgumentException if {@code duration} is zero or negative
    * @throws IllegalStateException if the refresh interval was already set
    * @throws ArithmeticException for durations greater than +/- approximately 292 years
    */


### PR DESCRIPTION
…vior for IllegalArgumentException

## Summary
- The current implementation and the current [test code](https://github.com/ben-manes/caffeine/blob/19f0911a78fa8096a4f610a24b756741dd4ed984/caffeine/src/test/java/com/github/benmanes/caffeine/cache/CaffeineTest.java#L513-L516) imply that `refreshAfterWrite` throws an `IllegalArgumentException` **also** when `duration` is zero. This pull request clarifies this fact in the Javadoc.