### PR TITLE
Bump checksum-dependency-plugin to 1.30.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ buildCache {
 // See https://github.com/vlsi/vlsi-release-plugins
 buildscript {
   dependencies {
-    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.29.0') {
+    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.30.0') {
       // Gradle ships kotlin-stdlib which is good enough
       exclude(group: "org.jetbrains.kotlin", module:"kotlin-stdlib")
     }
@@ -37,8 +37,8 @@ def expectedSha512 = [
     "okhttp-4.1.0.jar",
   "93E7A41BE44CC17FB500EA5CD84D515204C180AEC934491D11FC6A71DAEA761FB0EECEF865D6FD5C3D88AAF55DCE3C2C424BE5BA5D43BEBF48D05F1FA63FA8A7":
     "okio-2.2.2.jar",
-  "5C48E584427240305A72D7DCE8D3706FF9E4F421046CEA9521762D3BDC160E1E16BD6439EBA6E3428F10D95E8E2F9EDD727AE636ABBAC4DFD63B7E1E6E469B7":
-    "checksum-dependency-plugin-1.29.0.jar",
+  "ABB0A2BC23047D3C8D45D94D9E7FD765C7F6D303800DD6697DC6D9BE8118DC8F892DDA37011F95D0AAF2DA4F1DB4D00AF2A9A71D14D2B3ECB53B90337D3388EC":
+    "checksum-dependency-plugin-1.30.0.jar",
 ]
 
 def sha512(File file) {


### PR DESCRIPTION
It disables the plugin in case `dependencyUpdates` is on the task execution graph (the set of tasks is configurable via `checksumIgnoreOnTask` property)