### PR TITLE
Bump checksum-dependency-plugin -> 1.44, fix allDependencies

### DIFF
--- a/checksum.xml
+++ b/checksum.xml
@@ -58,6 +58,7 @@
     <trusted-key id='eb9d04a9a679fe18' group='com.uber.nullaway' />
     <trusted-key id='d0d1b9a54efd603d' group='com.univocity' />
     <trusted-key id='1861c322c56014b2' group='commons-beanutils' />
+    <trusted-key id='3faad2cd5ecbb314' group='commons-beanutils' />
     <trusted-key id='411063a3a0ffd119' group='commons-beanutils' />
     <trusted-key id='3faad2cd5ecbb314' group='commons-codec' />
     <trusted-key id='86fdc7e2a11262cb' group='commons-codec' />

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ buildCache {
 // See https://github.com/vlsi/vlsi-release-plugins
 buildscript {
   dependencies {
-    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.30.0') {
+    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.44.0') {
       // Gradle ships kotlin-stdlib which is good enough
       exclude(group: "org.jetbrains.kotlin", module:"kotlin-stdlib")
     }
@@ -37,8 +37,8 @@ def expectedSha512 = [
     "okhttp-4.1.0.jar",
   "93E7A41BE44CC17FB500EA5CD84D515204C180AEC934491D11FC6A71DAEA761FB0EECEF865D6FD5C3D88AAF55DCE3C2C424BE5BA5D43BEBF48D05F1FA63FA8A7":
     "okio-2.2.2.jar",
-  "ABB0A2BC23047D3C8D45D94D9E7FD765C7F6D303800DD6697DC6D9BE8118DC8F892DDA37011F95D0AAF2DA4F1DB4D00AF2A9A71D14D2B3ECB53B90337D3388EC":
-    "checksum-dependency-plugin-1.30.0.jar",
+  "A86B9B2CBA7BA99860EF2F23555F1E1C1D5CB790B1C47536C32FE7A0FDA48A55694A5457B9F42C60B4725F095B90506324BDE0299F08E9E76B5944FB308375AC":
+    "checksum-dependency-plugin-1.44.0.jar",
 ]
 
 def sha512(File file) {


### PR DESCRIPTION
v1.31.0, v1.33.0, v1.35.0 reduce the verbosity when downloading keys.
v1.31.0 adds `-PchecksumUpdateAll` property (==update `checksum.xml`, avoid failures)

I use `caffeine / allDependencies` for regression tests of `checksum-dependency-plugin`, so I would like the task to be working: https://travis-ci.org/vlsi/vlsi-release-plugins/jobs/609652585#L444-L444
