### PR TITLE
Make BoundedBuffer a public class so that it can be used in different…

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedBuffer.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedBuffer.java
@@ -28,7 +28,7 @@ import com.github.benmanes.caffeine.base.UnsafeAccess;
  * @author ben.manes@gmail.com (Ben Manes)
  * @param <E> the type of elements maintained by this buffer
  */
-final class BoundedBuffer<E> extends StripedBuffer<E> {
+public final class BoundedBuffer<E> extends StripedBuffer<E> {
   /*
    * A circular ring buffer stores the elements being transferred by the producers to the consumer.
    * The monotonically increasing count of reads and writes allow indexing sequentially to the next


### PR DESCRIPTION
… contexts

This is a simple request to make the BoundedBuffer class public. I found that class to be quite helpful in scenarios other than a LoadingCache and it'd be great to have it as part of Caffeine's offering