### PR TITLE
Extend Caffeine Simulator to handle different requests types

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Simulator.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Simulator.java
@@ -21,6 +21,7 @@ import static com.github.benmanes.caffeine.cache.simulator.Simulator.Message.STA
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.PrimitiveIterator;
@@ -104,12 +105,12 @@ public final class Simulator extends AbstractActor {
   /** Broadcast the trace events to all of the policy actors. */
   private void broadcast() {
     try (Stream<AccessEvent> events = eventStream()) {
-      LongArrayList batch = new LongArrayList(batchSize);
+      ArrayList<AccessEvent> batch = new ArrayList<AccessEvent>(batchSize);
       for (Iterator<AccessEvent> i = events.iterator(); i.hasNext();) {
-        batch.add(i.next().getKey());
+        batch.add(i.next());
         if (batch.size() == batchSize) {
           router.route(batch, self());
-          batch = new LongArrayList(batchSize);
+          batch = new ArrayList<AccessEvent>(batchSize);
         }
       }
       router.route(batch, self());

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Simulator.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Simulator.java
@@ -21,10 +21,13 @@ import static com.github.benmanes.caffeine.cache.simulator.Simulator.Message.STA
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.PrimitiveIterator;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TraceFormat;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyActor;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
@@ -100,10 +103,10 @@ public final class Simulator extends AbstractActor {
 
   /** Broadcast the trace events to all of the policy actors. */
   private void broadcast() {
-    try (LongStream events = eventStream()) {
+    try (Stream<AccessEvent> events = eventStream()) {
       LongArrayList batch = new LongArrayList(batchSize);
-      for (PrimitiveIterator.OfLong i = events.iterator(); i.hasNext();) {
-        batch.add(i.nextLong());
+      for (Iterator<AccessEvent> i = events.iterator(); i.hasNext();) {
+        batch.add(i.next().getKey());
         if (batch.size() == batchSize) {
           router.route(batch, self());
           batch = new LongArrayList(batchSize);
@@ -118,7 +121,7 @@ public final class Simulator extends AbstractActor {
   }
 
   /** Returns a stream of trace events. */
-  private LongStream eventStream() throws IOException {
+  private Stream<AccessEvent> eventStream() throws IOException {
     if (settings.isSynthetic()) {
       return Synthetic.generate(settings);
     }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Synthetic.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Synthetic.java
@@ -18,9 +18,12 @@ package com.github.benmanes.caffeine.cache.simulator;
 import static java.util.Locale.US;
 
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings.SyntheticSettings.HotspotSettings;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings.SyntheticSettings.UniformSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
+
 import site.ycsb.generator.CounterGenerator;
 import site.ycsb.generator.ExponentialGenerator;
 import site.ycsb.generator.HotspotIntegerGenerator;
@@ -40,7 +43,13 @@ public final class Synthetic {
   private Synthetic() {}
 
   /** Returns a sequence of events based on the setting's distribution. */
-  public static LongStream generate(BasicSettings settings) {
+  public static Stream<AccessEvent> generate(BasicSettings settings) {
+    return generateKeys(settings).mapToObj(num -> new AccessEvent(num));
+
+  }
+
+  /** Returns a sequence of keys based on the setting's distribution. */
+  public static LongStream generateKeys(BasicSettings settings) {
     int events = settings.synthetic().events();
     switch (settings.synthetic().distribution().toLowerCase(US)) {
       case "counter":
@@ -68,6 +77,7 @@ public final class Synthetic {
     }
   }
 
+  
   /**
    * Returns a sequence of unique integers.
    *

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/event/AccessEvent.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/event/AccessEvent.java
@@ -1,0 +1,13 @@
+package com.github.benmanes.caffeine.cache.simulator.event;
+
+public class AccessEvent {
+  private final long key;
+
+  public AccessEvent(long key) {
+    this.key = key;
+  }
+
+  public long getKey() {
+    return key;
+  }
+}

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/BinaryTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/BinaryTraceReader.java
@@ -27,8 +27,10 @@ import java.util.PrimitiveIterator;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.google.common.io.Closeables;
 
 /**
@@ -44,11 +46,11 @@ public abstract class BinaryTraceReader extends AbstractTraceReader {
 
   @Override
   @SuppressWarnings("PMD.CloseResource")
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     DataInputStream input = new DataInputStream(new BufferedInputStream(readFile()));
     LongStream stream = StreamSupport.longStream(Spliterators.spliteratorUnknownSize(
         new TraceIterator(input), Spliterator.ORDERED), /* parallel */ false);
-    return stream.onClose(() -> Closeables.closeQuietly(input));
+    return stream.onClose(() -> Closeables.closeQuietly(input)).mapToObj(num -> new AccessEvent(num));
   }
 
   /** Returns the next event from the input stream. */

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/TraceFormat.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/TraceFormat.java
@@ -20,7 +20,9 @@ import static java.util.Locale.US;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.address.AddressTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.arc.ArcTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.cache2k.Cache2kTraceReader;
@@ -70,12 +72,12 @@ public enum TraceFormat {
    */
   public TraceReader readFiles(List<String> filePaths) {
     return () -> {
-      LongStream events = LongStream.empty();
+      Stream<AccessEvent> events = Stream.empty();
       for (String path : filePaths) {
         List<String> parts = Splitter.on(':').limit(2).splitToList(path);
         TraceFormat format = (parts.size() == 1) ? this : named(parts.get(0));
-        LongStream next = format.factory.apply(Iterables.getLast(parts)).events();
-        events = LongStream.concat(events, next);
+        Stream<AccessEvent> next = format.factory.apply(Iterables.getLast(parts)).events();
+        events = Stream.concat(events, next);
       }
       return events;
     };

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/TraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/TraceReader.java
@@ -14,7 +14,9 @@
 package com.github.benmanes.caffeine.cache.simulator.parser;
 
 import java.io.IOException;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 
 /**
  * A reader to an access trace.
@@ -32,5 +34,5 @@ public interface TraceReader {
    *
    * @return a lazy stream of cache events
    */
-  LongStream events() throws IOException;
+  Stream<AccessEvent> events() throws IOException;
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/AddressTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/AddressTraceReader.java
@@ -16,8 +16,9 @@
 package com.github.benmanes.caffeine.cache.simulator.parser.address;
 
 import java.io.IOException;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 
 /**
@@ -33,10 +34,10 @@ public final class AddressTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     return lines()
         .map(line -> line.split(" ", 3)[1])
         .map(address -> address.substring(2))
-        .mapToLong(address -> Long.parseLong(address, 16));
+        .map(address -> new AccessEvent(Long.parseLong(address, 16)));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/arc/ArcTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/arc/ArcTraceReader.java
@@ -17,7 +17,9 @@ package com.github.benmanes.caffeine.cache.simulator.parser.arc;
 
 import java.io.IOException;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 
 /**
@@ -33,12 +35,12 @@ public final class ArcTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
-    return lines().flatMapToLong(line -> {
+  public Stream<AccessEvent> events() throws IOException {
+    return lines().flatMap(line -> {
       String[] array = line.split(" ", 3);
       long startBlock = Long.parseLong(array[0]);
       int sequence = Integer.parseInt(array[1]);
-      return LongStream.range(startBlock, startBlock + sequence);
+      return LongStream.range(startBlock, startBlock + sequence).mapToObj(num -> new AccessEvent(num));
     });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/climb/ClimbTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/climb/ClimbTraceReader.java
@@ -23,9 +23,10 @@ import java.util.PrimitiveIterator;
 import java.util.Scanner;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 
 /**
@@ -40,10 +41,11 @@ public final class ClimbTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     TraceIterator iterator = new TraceIterator(readFile());
     return StreamSupport.longStream(Spliterators.spliteratorUnknownSize(
-        iterator, Spliterator.ORDERED), /* parallel */ false).onClose(iterator::close);
+        iterator, Spliterator.ORDERED), /* parallel */ false).onClose(iterator::close)
+        .mapToObj(num -> new AccessEvent(num));
   }
 
   private static final class TraceIterator implements PrimitiveIterator.OfLong {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/gradle/GradleTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/gradle/GradleTraceReader.java
@@ -17,8 +17,9 @@ package com.github.benmanes.caffeine.cache.simulator.parser.gradle;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 
 /**
@@ -33,9 +34,9 @@ public final class GradleTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     return lines()
         .map(uuid -> new BigInteger(uuid, 16))
-        .mapToLong(num -> num.shiftRight(64).longValue() ^ num.longValue());
+        .map(num -> new AccessEvent(num.shiftRight(64).longValue() ^ num.longValue()));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/lirs/LirsTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/lirs/LirsTraceReader.java
@@ -16,8 +16,9 @@
 package com.github.benmanes.caffeine.cache.simulator.parser.lirs;
 
 import java.io.IOException;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 
 /**
@@ -32,10 +33,10 @@ public final class LirsTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     return lines()
         .filter(line -> !line.isEmpty())
         .filter(line -> !line.equals("*"))
-        .mapToLong(Long::parseLong);
+        .map(num -> new AccessEvent(Long.parseLong(num)));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
@@ -18,6 +18,8 @@ package com.github.benmanes.caffeine.cache.simulator.parser.rewrite;
 import java.io.BufferedWriter;
 import java.io.IOException;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
+
 /**
  * The trace output format.
  *
@@ -25,11 +27,11 @@ import java.io.IOException;
  */
 public enum OutputFormat {
   CLIMB {
-    @Override public void write(BufferedWriter writer, long event) throws IOException {
-      writer.write(Long.toString(event));
+    @Override public void write(BufferedWriter writer, AccessEvent accessEvent) throws IOException {
+      writer.write(Long.toString(accessEvent.getKey()));
       writer.newLine();
     }
   };
 
-  public abstract void write(BufferedWriter writer, long event) throws IOException;
+  public abstract void write(BufferedWriter writer, AccessEvent accessEvent) throws IOException;
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/Rewriter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/Rewriter.java
@@ -20,12 +20,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.PrimitiveIterator;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TraceFormat;
 import com.google.common.base.Stopwatch;
 
@@ -59,10 +62,10 @@ public final class Rewriter {
   public void run() throws IOException {
     int count = 0;
     Stopwatch stopwatch = Stopwatch.createStarted();
-    try (LongStream events = inputFormat.readFiles(inputFiles).events();
+    try (Stream<AccessEvent> events = inputFormat.readFiles(inputFiles).events();
          BufferedWriter writer = Files.newBufferedWriter(outputFile)) {
-      for (PrimitiveIterator.OfLong i = events.iterator(); i.hasNext();) {
-        outputFormat.write(writer, i.nextLong());
+      for (Iterator<AccessEvent> i = events.iterator(); i.hasNext();) {
+        outputFormat.write(writer, i.next());
         count++;
       }
     }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/cambridge/CambridgeTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/cambridge/CambridgeTraceReader.java
@@ -16,8 +16,9 @@
 package com.github.benmanes.caffeine.cache.simulator.parser.snia.cambridge;
 
 import java.io.IOException;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 
 /**
@@ -33,9 +34,9 @@ public final class CambridgeTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     return lines()
         .map(line -> line.split(",", 6))
-        .mapToLong(array -> Long.parseLong(array[4]));
+        .map(array -> new AccessEvent(Long.parseLong(array[4])));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/network/YoutubeTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/network/YoutubeTraceReader.java
@@ -16,8 +16,9 @@
 package com.github.benmanes.caffeine.cache.simulator.parser.umass.network;
 
 import java.io.IOException;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.google.common.hash.Hashing;
 
@@ -34,10 +35,10 @@ public final class YoutubeTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     return lines()
         .map(line -> line.split(" "))
         .filter(array -> array[3].equals("GETVIDEO"))
-        .mapToLong(array -> Hashing.murmur3_128().hashUnencodedChars(array[4]).asLong());
+        .map(array -> new AccessEvent(Hashing.murmur3_128().hashUnencodedChars(array[4]).asLong()));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
@@ -18,7 +18,9 @@ package com.github.benmanes.caffeine.cache.simulator.parser.umass.storage;
 import java.io.IOException;
 import java.math.RoundingMode;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.google.common.math.IntMath;
 
@@ -36,19 +38,19 @@ public final class StorageTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
-    return lines().flatMapToLong(line -> {
+  public Stream<AccessEvent> events() throws IOException {
+    return lines().flatMap(line -> {
       String[] array = line.split(",", 5);
       if (array.length <= 4) {
-        return LongStream.empty();
+        return Stream.empty();
       }
       long startBlock = Long.parseLong(array[1]);
       int size = Integer.parseInt(array[2]);
       int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
       char readWrite = Character.toLowerCase(array[3].charAt(0));
       return (readWrite == 'w')
-          ? LongStream.empty()
-          : LongStream.range(startBlock, startBlock + sequence);
+          ? Stream.empty()
+          : LongStream.range(startBlock, startBlock + sequence).mapToObj(num -> new AccessEvent(num));
     });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/wikipedia/WikipediaTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/wikipedia/WikipediaTraceReader.java
@@ -17,11 +17,12 @@ package com.github.benmanes.caffeine.cache.simulator.parser.wikipedia;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.google.common.hash.Hashing;
 
@@ -44,11 +45,11 @@ public final class WikipediaTraceReader extends TextTraceReader {
   }
 
   @Override
-  public LongStream events() throws IOException {
+  public Stream<AccessEvent> events() throws IOException {
     return lines()
         .map(this::parseRequest)
         .filter(Objects::nonNull)
-        .mapToLong(path -> Hashing.murmur3_128().hashUnencodedChars(path).asLong());
+        .map(path -> new AccessEvent(Hashing.murmur3_128().hashUnencodedChars(path).asLong()));
   }
 
   /**

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/Policy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/Policy.java
@@ -15,6 +15,8 @@
  */
 package com.github.benmanes.caffeine.cache.simulator.policy;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
+
 /**
  * A cache that implements a page replacement policy.
  *
@@ -23,7 +25,7 @@ package com.github.benmanes.caffeine.cache.simulator.policy;
 public interface Policy {
 
   /** Records that the entry was accessed. */
-  void record(long key);
+  void record(AccessEvent event);
 
   /** Indicates that the recording has completed. */
   default void finished() {}

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyActor.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyActor.java
@@ -19,6 +19,10 @@ import static com.github.benmanes.caffeine.cache.simulator.Simulator.Message.ERR
 import static com.github.benmanes.caffeine.cache.simulator.Simulator.Message.FINISH;
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
+
 import akka.actor.AbstractActor;
 import akka.dispatch.BoundedMessageQueueSemantics;
 import akka.dispatch.RequiresMessageQueue;
@@ -40,16 +44,16 @@ public final class PolicyActor extends AbstractActor
   @Override
   public Receive createReceive() {
     return receiveBuilder()
-        .match(LongArrayList.class, this::process)
+        .match(ArrayList.class, this::process)
         .matchEquals(FINISH, msg -> finish())
         .build();
   }
 
-  private void process(LongArrayList events) {
+  private void process(ArrayList<AccessEvent> events) {
     try {
       policy.stats().stopwatch().start();
       for (int i = 0; i < events.size(); i++) {
-        policy.record(events.getLong(i));
+        policy.record(events.get(i));
       }
     } catch (Exception e) {
       sender().tell(ERROR, self());

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/ArcPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/ArcPolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -89,7 +90,8 @@ public final class ArcPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/CarPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/CarPolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -75,7 +76,8 @@ public final class CarPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Node node = data.get(key);
     if (isHit(node)) {
       policyStats.recordHit();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/CartPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/CartPolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -79,7 +80,8 @@ public final class CartPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Node node = data.get(key);
     if (isHit(node)) {
       policyStats.recordHit();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPolicy.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -100,7 +101,8 @@ public final class ClockProPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Node node = data.get(key);
 
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/FrdPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/FrdPolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -76,7 +77,8 @@ public final class FrdPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/HillClimberFrdPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/HillClimberFrdPolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -80,7 +81,8 @@ public final class HillClimberFrdPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     adapt();
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/IndicatorFrdPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/IndicatorFrdPolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.github.benmanes.caffeine.cache.simulator.policy.sketch.Indicator;
@@ -71,7 +72,8 @@ public final class IndicatorFrdPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     adapt(key);
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsPolicy.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -94,7 +95,8 @@ public final class LirsPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/FrequentlyUsedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/FrequentlyUsedPolicy.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admission;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -72,7 +73,8 @@ public final class FrequentlyUsedPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     admittor.record(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admission;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -72,7 +73,8 @@ public final class LinkedPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Node old = data.get(key);
     admittor.record(key);
     if (old == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/MultiQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/MultiQueuePolicy.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -83,7 +84,8 @@ public final class MultiQueuePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/S4LruPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/S4LruPolicy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admission;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -75,7 +76,8 @@ public final class S4LruPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     admittor.record(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/SegmentedLruPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/SegmentedLruPolicy.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admission;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -83,7 +84,8 @@ public final class SegmentedLruPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     admittor.record(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/opt/ClairvoyantPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/opt/ClairvoyantPolicy.java
@@ -18,6 +18,7 @@ package com.github.benmanes.caffeine.cache.simulator.policy.opt;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -63,7 +64,8 @@ public final class ClairvoyantPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     tick++;
     future.enqueue(key);
     IntPriorityQueue times = accessTimes.get(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/opt/UnboundedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/opt/UnboundedPolicy.java
@@ -17,6 +17,7 @@ package com.github.benmanes.caffeine.cache.simulator.policy.opt;
 
 import java.util.Set;
 
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -51,7 +52,8 @@ public final class UnboundedPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     if (data.add(key)) {
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Cache2kPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Cache2kPolicy.java
@@ -23,6 +23,7 @@ import org.cache2k.Cache;
 import org.cache2k.Cache2kBuilder;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -59,7 +60,8 @@ public final class Cache2kPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.peek(key);
     if (value == null) {
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -52,7 +53,8 @@ public final class CaffeinePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.getIfPresent(key);
     if (value == null) {
       if (cache.estimatedSize() == maximumSize) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CollisionPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CollisionPolicy.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.typesafe.config.Config;
@@ -72,7 +73,8 @@ public final class CollisionPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.getIfPresent(key);
     if (value == null) {
       if (trackedSize == maximumSize) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Ehcache3Policy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Ehcache3Policy.java
@@ -25,6 +25,7 @@ import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.EntryUnit;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -61,7 +62,8 @@ public final class Ehcache3Policy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.putIfAbsent(key, key);
     if (value == null) {
       size++;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ElasticSearchPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ElasticSearchPolicy.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.cache.Cache.CacheStats;
 import org.elasticsearch.common.cache.CacheBuilder;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -54,7 +55,8 @@ public final class ElasticSearchPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.get(key);
     if (value == null) {
       if (cache.count() == maximumSize) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ExpiringMapPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ExpiringMapPolicy.java
@@ -20,6 +20,7 @@ import static java.util.Locale.US;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -52,7 +53,8 @@ public final class ExpiringMapPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.get(key);
     if (value == null) {
       if (cache.size() == cache.getMaxSize()) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/GuavaPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/GuavaPolicy.java
@@ -18,6 +18,7 @@ package com.github.benmanes.caffeine.cache.simulator.policy.product;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.cache.Cache;
@@ -50,7 +51,8 @@ public final class GuavaPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.getIfPresent(key);
     if (value == null) {
       cache.put(key, key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/OhcPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/OhcPolicy.java
@@ -31,6 +31,7 @@ import org.caffinitas.ohc.OHCache;
 import org.caffinitas.ohc.OHCacheBuilder;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.typesafe.config.Config;
@@ -67,7 +68,8 @@ public final class OhcPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.get(key);
     if (value == null) {
       cache.put(key, key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/TCachePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/TCachePolicy.java
@@ -20,6 +20,7 @@ import static java.util.Locale.US;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -55,7 +56,8 @@ public final class TCachePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Object value = cache.get(key);
     if (value == null) {
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sampled/SampledPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sampled/SampledPolicy.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admission;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -91,7 +92,8 @@ public final class SampledPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Node node = data.get(key);
     admittor.record(key);
     long now = ++tick;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/WindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/WindowTinyLfuPolicy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -94,7 +95,8 @@ public final class WindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/HillClimberWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/HillClimberWindowTinyLfuPolicy.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.HillClimber.Adaptation;
@@ -117,7 +118,8 @@ public final class HillClimberWindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     boolean isFull = (data.size() >= maximumSize);
     policyStats.recordOperation();
     Node node = data.get(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/sim/MiniSimClimber.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/sim/MiniSimClimber.java
@@ -18,6 +18,7 @@ package com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.sim;
 import java.util.List;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.sketch.WindowTinyLfuPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.sketch.WindowTinyLfuPolicy.WindowTinyLfuSettings;
 import com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.HillClimber;
@@ -81,7 +82,7 @@ public final class MiniSimClimber implements HillClimber {
 
     if (Math.floorMod(hasher.hashLong(key).asInt(), R) < 1) {
       for (WindowTinyLfuPolicy policy : minis) {
-        policy.record(key);
+        policy.record(new AccessEvent(key)); // Bad temporary fix
       }
     }
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackTinyLfuPolicy.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.membership.Membership;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
@@ -86,7 +87,8 @@ public final class FeedbackTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     if ((sample % sampleSize) == 0) {
       sampled++;
     }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackWindowTinyLfuPolicy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.membership.Membership;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
@@ -118,7 +119,8 @@ public final class FeedbackWindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     if ((sample % sampleSize) == 0) {
       sampled++;
     }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/FullySegmentedWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/FullySegmentedWindowTinyLfuPolicy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.github.benmanes.caffeine.cache.simulator.policy.linked.SegmentedLruPolicy;
@@ -91,7 +92,8 @@ public final class FullySegmentedWindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     admittor.record(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/LruWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/LruWindowTinyLfuPolicy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -76,7 +77,8 @@ public final class LruWindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     admittor.record(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/RandomWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/RandomWindowTinyLfuPolicy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -77,7 +78,8 @@ public final class RandomWindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     Node node = data.get(key);
     admittor.record(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/S4WindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/S4WindowTinyLfuPolicy.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Admittor;
 import com.github.benmanes.caffeine.cache.simulator.admission.TinyLfu;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -83,7 +84,8 @@ public final class S4WindowTinyLfuPolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     admittor.record(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/tinycache/TinyCachePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/tinycache/TinyCachePolicy.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.tinycache.TinyCache;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -44,7 +45,8 @@ public final class TinyCachePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     if (tinyCache.contains(key)) {
       policyStats.recordHit();
     } else {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/tinycache/TinyCacheWithGhostCachePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/tinycache/TinyCacheWithGhostCachePolicy.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.tinycache.TinyCacheWithGhostCache;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -44,7 +45,8 @@ public final class TinyCacheWithGhostCachePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     if (tinyCache.contains(key)) {
       tinyCache.recordItem(key);
       policyStats.recordHit();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/tinycache/WindowTinyCachePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/tinycache/WindowTinyCachePolicy.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.tinycache.TinyCache;
 import com.github.benmanes.caffeine.cache.simulator.admission.tinycache.TinyCacheWithGhostCache;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.collect.ImmutableSet;
@@ -53,7 +54,8 @@ public final class WindowTinyCachePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     if (tinyCache.contains(key) || ((window != null) && window.contains(key))) {
       tinyCache.recordItem(key);
       policyStats.recordHit();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TuQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TuQueuePolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -87,7 +88,8 @@ public class TuQueuePolicy implements Policy {
   }
 
   @Override
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     policyStats.recordOperation();
     Node node = data.get(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TwoQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TwoQueuePolicy.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Set;
 
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
+import com.github.benmanes.caffeine.cache.simulator.event.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
@@ -80,7 +81,8 @@ public final class TwoQueuePolicy implements Policy {
 
   @Override
   @SuppressWarnings({"PMD.ConfusingTernary", "PMD.SwitchStmtsShouldHaveDefault"})
-  public void record(long key) {
+  public void record(AccessEvent event) {
+    final long key = event.getKey();
     // On accessing a page X :
     //   if X is in Am then
     //     move X to the head of Am


### PR DESCRIPTION
We aim to extend Caffeine Simulator to handle different requests types, such as size-aware and latency-aware requests. 
To do so, we first create an AccessEvent class that will handle all the requests during parsing and processing. For now, it handles only regular key accesses. 
This is still WIP, but I opened the pull-request so you can review and comment along the way.
