### PR TITLE
Make linked policies simulation weight-aware

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/AccessEvent.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/AccessEvent.java
@@ -101,7 +101,7 @@ public class AccessEvent {
     private final int weight;
 
     WeightedAccessEvent(long key, int weight) {
-      super(key);
+      super(cantorHashCode(key, weight));
       this.weight = weight;
       checkArgument(weight >= 0);
     }
@@ -110,6 +110,11 @@ public class AccessEvent {
     public int weight() {
       return weight;
     }
+  }
+
+  /** Cantor pairing function. */
+  private static long cantorHashCode(long key, int weight) {
+    return (key + weight) * (key + weight + 1) / 2 + weight;
   }
 
   private static final class PenaltiesAccessEvent extends AccessEvent {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyStats.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyStats.java
@@ -83,6 +83,7 @@ public final class PolicyStats {
 
   public void recordWeightedHit(int weight) {
     hitsWeight += weight;
+    recordHit();
   }  
   
   public long hitsWeight() {
@@ -111,6 +112,7 @@ public final class PolicyStats {
 
   public void recordWeightedMiss(int weight) {
     missesWeight += weight;
+    recordMiss();
   }  
   
   public long missesWeight() {
@@ -184,7 +186,6 @@ public final class PolicyStats {
     long requestsWeight = requestsWeight();
     return (requestsWeight == 0) ? 1.0 : (double) missesWeight / requestsWeight;
   }
-
 
   public double admissionRate() {
     long candidateCount = admittedCount + rejectedCount;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyStats.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyStats.java
@@ -31,6 +31,8 @@ public final class PolicyStats {
   private String name;
   private long hitCount;
   private long missCount;
+  private long hitsWeight;
+  private long missesWeight;
   private double hitPenalty;
   private double missPenalty;
   private long evictionCount;
@@ -79,6 +81,14 @@ public final class PolicyStats {
     hitCount += hits;
   }
 
+  public void recordWeightedHit(int weight) {
+    hitsWeight += weight;
+  }  
+  
+  public long hitsWeight() {
+    return hitsWeight;
+  }
+  
   public void recordHitPenalty(double penalty) {
     hitPenalty += penalty;
   }
@@ -99,6 +109,14 @@ public final class PolicyStats {
     missCount += misses;
   }
 
+  public void recordWeightedMiss(int weight) {
+    missesWeight += weight;
+  }  
+  
+  public long missesWeight() {
+    return missesWeight;
+  }
+  
   public void recordMissPenalty(double penalty) {
     missPenalty += penalty;
   }
@@ -121,6 +139,10 @@ public final class PolicyStats {
 
   public long requestCount() {
     return hitCount + missCount;
+  }
+
+  public long requestsWeight() {
+    return hitsWeight + missesWeight;
   }
 
   public long admissionCount() {
@@ -148,10 +170,21 @@ public final class PolicyStats {
     return (requestCount == 0) ? 1.0 : (double) hitCount / requestCount;
   }
 
+  public double weightedHitRate() {
+    long requestsWeight = requestsWeight();
+    return (requestsWeight == 0) ? 1.0 : (double) hitsWeight / requestsWeight;
+  }
+
   public double missRate() {
     long requestCount = requestCount();
     return (requestCount == 0) ? 0.0 : (double) missCount / requestCount;
   }
+
+  public double weightedMissRate() {
+    long requestsWeight = requestsWeight();
+    return (requestsWeight == 0) ? 1.0 : (double) missesWeight / requestsWeight;
+  }
+
 
   public double admissionRate() {
     long candidateCount = admittedCount + rejectedCount;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
@@ -89,6 +89,7 @@ public final class LinkedPolicy implements Policy {
     admittor.record(key);
     if (old == null) {
       policyStats.recordMiss();
+      policyStats.recordWeightedMiss(weight);
       if (weight > maximumSize) {
         policyStats.recordOperation();
         return;
@@ -100,6 +101,7 @@ public final class LinkedPolicy implements Policy {
       evict(node);
     } else {
       policyStats.recordHit();
+      policyStats.recordWeightedHit(weight);
       policy.onAccess(old, policyStats);
     }
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
@@ -50,8 +50,8 @@ public final class LinkedPolicy implements Policy {
   final EvictionPolicy policy;
   final Admittor admittor;
   final int maximumSize;
-  int currentSize;
   final Node sentinel;
+  int currentSize;
 
   public LinkedPolicy(Admission admission, EvictionPolicy policy, Config config) {
     this.policyStats = new PolicyStats(admission.format("linked." + policy.label()));
@@ -88,7 +88,6 @@ public final class LinkedPolicy implements Policy {
     Node old = data.get(key);
     admittor.record(key);
     if (old == null) {
-      policyStats.recordMiss();
       policyStats.recordWeightedMiss(weight);
       if (weight > maximumSize) {
         policyStats.recordOperation();
@@ -100,7 +99,6 @@ public final class LinkedPolicy implements Policy {
       node.appendToTail();
       evict(node);
     } else {
-      policyStats.recordHit();
       policyStats.recordWeightedHit(weight);
       policy.onAccess(old, policyStats);
     }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
@@ -18,8 +18,6 @@ package com.github.benmanes.caffeine.cache.simulator.policy.linked;
 import static java.util.Locale.US;
 import static java.util.stream.Collectors.toSet;
 
-import java.util.Objects;
-
 import static com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic.WEIGHTED;
 
 import java.util.Set;
@@ -86,7 +84,7 @@ public final class LinkedPolicy implements Policy {
   @Override
   public void record(AccessEvent event) {
     final int weight = event.weight();
-    final long key = hashCode(event.key(), weight);
+    final long key = event.key();
     Node old = data.get(key);
     admittor.record(key);
     if (old == null) {
@@ -268,10 +266,5 @@ public final class LinkedPolicy implements Policy {
           .add("marked", marked)
           .toString();
     }
-  }
-  
-  /** Cantor pairing function. */
-  private long hashCode(long key, int weight) {
-    return (key + weight) * (key + weight + 1) / 2 + weight;
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Cache2kPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Cache2kPolicy.java
@@ -76,12 +76,14 @@ public final class Cache2kPolicy implements Policy {
     Object value = cache.peek(event.key());
     if (value == null) {
       policyStats.recordMiss();
+      policyStats.recordWeightedMiss(event.weight());
       if (cache.asMap().size() == maximumSize) {
         policyStats.recordEviction();
       }
       cache.put(event.key(), event);
     } else {
       policyStats.recordHit();
+      policyStats.recordWeightedHit(event.weight());
     }
   }
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Cache2kPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/Cache2kPolicy.java
@@ -75,14 +75,12 @@ public final class Cache2kPolicy implements Policy {
   public void record(AccessEvent event) {
     Object value = cache.peek(event.key());
     if (value == null) {
-      policyStats.recordMiss();
       policyStats.recordWeightedMiss(event.weight());
       if (cache.asMap().size() == maximumSize) {
         policyStats.recordEviction();
       }
       cache.put(event.key(), event);
     } else {
-      policyStats.recordHit();
       policyStats.recordWeightedHit(event.weight());
     }
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
@@ -67,8 +67,10 @@ public final class CaffeinePolicy implements Policy {
     if (value == null) {
       cache.put(event.key(), event);
       policyStats.recordMiss();
+      policyStats.recordWeightedMiss(event.weight());
     } else {
       policyStats.recordHit();
+      policyStats.recordWeightedHit(event.weight());
     }
   }
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
@@ -66,10 +66,8 @@ public final class CaffeinePolicy implements Policy {
     Object value = cache.getIfPresent(event.key());
     if (value == null) {
       cache.put(event.key(), event);
-      policyStats.recordMiss();
       policyStats.recordWeightedMiss(event.weight());
     } else {
-      policyStats.recordHit();
       policyStats.recordWeightedHit(event.weight());
     }
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ElasticSearchPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ElasticSearchPolicy.java
@@ -66,8 +66,10 @@ public final class ElasticSearchPolicy implements Policy {
     if (value == null) {
       cache.put(event.key(), event);
       policyStats.recordMiss();
+      policyStats.recordWeightedMiss(event.weight());
     } else {
       policyStats.recordHit();
+      policyStats.recordWeightedHit(event.weight());
     }
   }
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ElasticSearchPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/ElasticSearchPolicy.java
@@ -65,10 +65,8 @@ public final class ElasticSearchPolicy implements Policy {
     Object value = cache.get(event.key());
     if (value == null) {
       cache.put(event.key(), event);
-      policyStats.recordMiss();
       policyStats.recordWeightedMiss(event.weight());
     } else {
-      policyStats.recordHit();
       policyStats.recordWeightedHit(event.weight());
     }
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/GuavaPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/GuavaPolicy.java
@@ -63,11 +63,9 @@ public final class GuavaPolicy implements Policy {
     Object value = cache.getIfPresent(event.key());
     if (value == null) {
       cache.put(event.key(), event);
-      policyStats.recordMiss();
       policyStats.recordWeightedMiss(event.weight());
     } else {
       policyStats.recordWeightedHit(event.weight());
-      policyStats.recordHit();
     }
   }
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/GuavaPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/GuavaPolicy.java
@@ -64,7 +64,9 @@ public final class GuavaPolicy implements Policy {
     if (value == null) {
       cache.put(event.key(), event);
       policyStats.recordMiss();
+      policyStats.recordWeightedMiss(event.weight());
     } else {
+      policyStats.recordWeightedHit(event.weight());
       policyStats.recordHit();
     }
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/CsvReporter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/CsvReporter.java
@@ -49,6 +49,8 @@ public final class CsvReporter extends TextReporter {
           policyStats.requestCount(),
           policyStats.evictionCount(),
           String.format("%.2f", 100 * policyStats.admissionRate()),
+          policyStats.requestsWeight(),
+          String.format("%.2f", 100 * policyStats.weightedHitRate()),
           String.format("%.2f", policyStats.averageMissPenalty()),
           String.format("%.2f", policyStats.avergePenalty()),
           (policyStats.operationCount() == 0) ? null : policyStats.operationCount(),

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TableReporter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TableReporter.java
@@ -47,6 +47,8 @@ public final class TableReporter extends TextReporter {
           String.format("%,d", policyStats.requestCount()),
           String.format("%,d", policyStats.evictionCount()),
           String.format("%.2f %%", 100 * policyStats.admissionRate()),
+          String.format("%,d", policyStats.requestsWeight()),
+          String.format("%.2f %%", 100 * policyStats.weightedHitRate()),
           String.format("%.2f", policyStats.averageMissPenalty()),
           String.format("%.2f", policyStats.avergePenalty()),
           steps(policyStats),

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporter.java
@@ -38,7 +38,8 @@ import com.typesafe.config.Config;
 public abstract class TextReporter implements Reporter {
   private static final String[] HEADERS = {
       "Policy", "Hit rate", "Hits", "Misses", "Requests", "Evictions",
-      "Admit rate", "Average Miss Penalty", "Average Penalty", "Steps", "Time"};
+      "Admit rate", "Requests Weight", "Weighted Hit Rate", "Average Miss Penalty", 
+      "Average Penalty", "Steps", "Time"};
 
   private final List<PolicyStats> results;
   private final BasicSettings settings;


### PR DESCRIPTION
I changed the linked policies (LRU, MRU, FIFO, Clock) to be able to work with weighted traces.
I validate that they work the same as before for unweighed traces, and the new implementation has identical results to [webcachesim](https://github.com/dasebe/webcachesim) simulator (for LRU and FIFO).

Notice that if the admission policy is not Always, the behavior is to evict victims one by one as long as the candidate wins and admit when there is enough space (similar to [Ristretto](https://github.com/dgraph-io/ristretto) approach and not to Caffeine current approach).