### PR TITLE
Fix SCM connection URLs when publishing

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -38,8 +38,8 @@ publishing {
 
         scm {
           url = 'https://github.com/ben-manes/caffeine'
-          connection = 'scm:https://ben-manes@github.com/ben-manes/caffeine.git'
-          developerConnection = 'scm:git://github.com/ben-manes/caffeine.git'
+          connection = 'scm:git:https://github.com/ben-manes/caffeine.git'
+          developerConnection = 'scm:git:ssh://git@github.com/ben-manes/caffeine.git'
         }
 
         licenses {


### PR DESCRIPTION
Both URLs were missing the [provider] part (here "git"), see https://maven.apache.org/pom.html#SCM.
Also, the connection URL must be usable for anonymous clones, so it should not contain a user name.
Finally, GitHub does not endorse the use of the "git" protocol, so use "ssh" for the authenticated developer
connection instead.