### PR TITLE
Allow rewriting ARC traces to AdaptSize format

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/arc/ArcTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/arc/ArcTraceReader.java
@@ -15,11 +15,17 @@
  */
 package com.github.benmanes.caffeine.cache.simulator.parser.arc;
 
+import static com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic.WEIGHTED;
+
 import java.io.IOException;
+import java.util.Set;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
-import com.github.benmanes.caffeine.cache.simulator.parser.TraceReader.KeyOnlyTraceReader;
+import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
+import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
+import com.google.common.collect.Sets;
 
 /**
  * A reader for the trace files provided by the authors of the ARC algorithm. See
@@ -27,19 +33,24 @@ import com.github.benmanes.caffeine.cache.simulator.parser.TraceReader.KeyOnlyTr
  *
  * @author ben.manes@gmail.com (Ben Manes)
  */
-public final class ArcTraceReader extends TextTraceReader implements KeyOnlyTraceReader {
+public final class ArcTraceReader extends TextTraceReader {
 
   public ArcTraceReader(String filePath) {
     super(filePath);
   }
 
   @Override
-  public LongStream keys() throws IOException {
-    return lines().flatMapToLong(line -> {
+  public Set<Characteristic> characteristics() {
+    return Sets.immutableEnumSet(WEIGHTED);
+  }  
+
+  @Override
+  public Stream<AccessEvent> events() throws IOException {
+    return lines().flatMap(line -> {
       String[] array = line.split(" ", 3);
       long startBlock = Long.parseLong(array[0]);
       int sequence = Integer.parseInt(array[1]);
-      return LongStream.range(startBlock, startBlock + sequence);
+      return LongStream.range(startBlock, startBlock + sequence).mapToObj(key -> AccessEvent.forKeyAndWeight(key, 512));
     });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/arc/ArcTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/arc/ArcTraceReader.java
@@ -50,7 +50,8 @@ public final class ArcTraceReader extends TextTraceReader {
       String[] array = line.split(" ", 3);
       long startBlock = Long.parseLong(array[0]);
       int sequence = Integer.parseInt(array[1]);
-      return LongStream.range(startBlock, startBlock + sequence).mapToObj(key -> AccessEvent.forKeyAndWeight(key, 512));
+      return LongStream.range(startBlock, startBlock + sequence)
+          .mapToObj(key -> AccessEvent.forKeyAndWeight(key, 512));
     });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
@@ -27,20 +27,19 @@ import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
  */
 public enum OutputFormat {
   CLIMB {
-    @Override public void write(BufferedWriter writer, AccessEvent event) throws IOException {
+    @Override public void write(BufferedWriter writer, AccessEvent event, long time) throws IOException {
       writer.write(Long.toString(event.key()));
       writer.newLine();
     }
   },
   ADAPT_SIZE {
-    long time = 0;
-    @Override public void write(BufferedWriter writer, AccessEvent event) throws IOException {
-      writer.write(Long.toString(time++) + " ");
+    @Override public void write(BufferedWriter writer, AccessEvent event, long time) throws IOException {
+      writer.write(Long.toString(time) + " ");
       writer.write(Long.toString(event.key()) + " ");
       writer.write(Integer.toString(event.weight()));
       writer.newLine();
     }
   };
 
-  public abstract void write(BufferedWriter writer, AccessEvent event) throws IOException;
+  public abstract void write(BufferedWriter writer, AccessEvent event, long time) throws IOException;
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
@@ -35,7 +35,9 @@ public enum OutputFormat {
   ADAPT_SIZE {
     long time = 0;
     @Override public void write(BufferedWriter writer, AccessEvent event) throws IOException {
-      writer.write(Long.toString(time++) + " " + Long.toString(event.key()) + " " + Integer.toString(event.weight()));
+      writer.write(Long.toString(time++) + " ");
+      writer.write(Long.toString(event.key()) + " ");
+      writer.write(Integer.toString(event.weight()));
       writer.newLine();
     }
   };

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/OutputFormat.java
@@ -18,6 +18,8 @@ package com.github.benmanes.caffeine.cache.simulator.parser.rewrite;
 import java.io.BufferedWriter;
 import java.io.IOException;
 
+import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
+
 /**
  * The trace output format.
  *
@@ -25,11 +27,18 @@ import java.io.IOException;
  */
 public enum OutputFormat {
   CLIMB {
-    @Override public void write(BufferedWriter writer, long event) throws IOException {
-      writer.write(Long.toString(event));
+    @Override public void write(BufferedWriter writer, AccessEvent event) throws IOException {
+      writer.write(Long.toString(event.key()));
+      writer.newLine();
+    }
+  },
+  ADAPT_SIZE {
+    long time = 0;
+    @Override public void write(BufferedWriter writer, AccessEvent event) throws IOException {
+      writer.write(Long.toString(time++) + " " + Long.toString(event.key()) + " " + Integer.toString(event.weight()));
       writer.newLine();
     }
   };
 
-  public abstract void write(BufferedWriter writer, long event) throws IOException;
+  public abstract void write(BufferedWriter writer, AccessEvent event) throws IOException;
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/Rewriter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/Rewriter.java
@@ -64,7 +64,7 @@ public final class Rewriter {
     try (Stream<AccessEvent> events = inputFormat.readFiles(inputFiles).events();
          BufferedWriter writer = Files.newBufferedWriter(outputFile)) {
       for (Iterator<AccessEvent> i = events.iterator(); i.hasNext();) {
-        outputFormat.write(writer, i.next().key());
+        outputFormat.write(writer, i.next());
         count++;
       }
     }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/Rewriter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/rewrite/Rewriter.java
@@ -59,12 +59,12 @@ public final class Rewriter {
 
   @SuppressWarnings("PMD.ForLoopCanBeForeach")
   public void run() throws IOException {
-    int count = 0;
+    long count = 0;
     Stopwatch stopwatch = Stopwatch.createStarted();
     try (Stream<AccessEvent> events = inputFormat.readFiles(inputFiles).events();
          BufferedWriter writer = Files.newBufferedWriter(outputFile)) {
       for (Iterator<AccessEvent> i = events.iterator(); i.hasNext();) {
-        outputFormat.write(writer, i.next());
+        outputFormat.write(writer, i.next(), count);
         count++;
       }
     }


### PR DESCRIPTION
Change ARC parser to support size-aware events. Size is always 512.
Support rewriting of size-aware events.
Add output format of AdaptSize.