### PR TITLE
Add support for Outbrain traces

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/TraceFormat.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/TraceFormat.java
@@ -34,6 +34,7 @@ import com.github.benmanes.caffeine.cache.simulator.parser.climb.ClimbTraceReade
 import com.github.benmanes.caffeine.cache.simulator.parser.corda.CordaTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.gradle.GradleTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.lirs.LirsTraceReader;
+import com.github.benmanes.caffeine.cache.simulator.parser.kaggle.OutbrainTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.scarab.ScarabTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.snia.cambridge.CambridgeTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.umass.network.YoutubeTraceReader;
@@ -62,6 +63,7 @@ public enum TraceFormat {
   CORDA(CordaTraceReader::new),
   GRADLE(GradleTraceReader::new),
   LIRS(LirsTraceReader::new),
+  OUTBRAIN(OutbrainTraceReader::new),
   SCARAB(ScarabTraceReader::new),
   SNIA_CAMBRIDGE(CambridgeTraceReader::new),
   UMASS_STORAGE(StorageTraceReader::new),

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/kaggle/OutbrainTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/kaggle/OutbrainTraceReader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.parser.kaggle;
+
+import java.io.IOException;
+import java.util.stream.LongStream;
+
+import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
+import com.github.benmanes.caffeine.cache.simulator.parser.TraceReader.KeyOnlyTraceReader;
+import com.google.common.hash.Hashing;
+
+/**
+ * A reader for the page views log provided by
+ * <a href="https://www.kaggle.com/c/outbrain-click-prediction/data">Outbrain</a>.
+ * Notice: you should reorder the file according to the timestamp, e.g. by 
+ * {@code sort -t, -k 3,3n -s page_views_sample.csv > page_views_sample_sorted.csv}
+ *
+ * @author ohadey@gmail.com (Ohad Eytan)
+ */
+public final class OutbrainTraceReader extends TextTraceReader implements KeyOnlyTraceReader {
+
+  public OutbrainTraceReader(String filePath) {
+    super(filePath);
+  }
+
+  @Override
+  public LongStream keys() throws IOException {
+    return lines().skip(1)
+        .map(line -> line.split(","))
+        .mapToLong(array -> Long.parseLong(array[1]));
+  }
+}

--- a/simulator/src/main/resources/reference.conf
+++ b/simulator/src/main/resources/reference.conf
@@ -452,6 +452,7 @@ caffeine.simulator {
     # corda: format of Corda traces
     # gradle: format from the authors of the Gradle build tool
     # lirs: format from the authors of the LIRS algorithm
+    # outbrain: format from Outbrain trace provided on Kaggle
     # scarab: format of Scarab Research traces
     # snia-cambridge: format from the SNIA MSR Cambridge traces
     # umass-storage: format from the University of Massachusetts storage traces


### PR DESCRIPTION
A nice trace of Outbrain [provided](https://www.kaggle.com/c/outbrain-click-prediction/data) by Kaggle.