### PR TITLE
fix #447: Allow the CaffeineCachingProvider to be used with OSGi DS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,17 +73,9 @@ subprojects {
     testRuntimeOnly testLibraries.osgiRuntime
   }
 
-  configurations {
-    bundleCompile
-  }
-
-  sourceSets {
-    bundle
-  }
-
   task bundle(type: aQute.bnd.gradle.Bundle) {
-    from sourceSets.bundle.output
-    sourceSet = sourceSets.bundle
+    from sourceSets.main.output
+    sourceSet = sourceSets.main
   }
 
   tasks.withType(JavaCompile) {

--- a/checksum.xml
+++ b/checksum.xml
@@ -123,6 +123,7 @@
     <trusted-key id='9ae296fd02e9f65b' group='org.apache.commons' />
     <trusted-key id='a2115ae15f6b8b72' group='org.apache.commons' />
     <trusted-key id='9054823a859a7237' group='org.apache.felix' />
+    <trusted-key id='3fcf529ff2f27a06' group='org.apache.felix' />
     <trusted-key id='de78987a9cd4d9d3' group='org.apache.htrace' />
     <trusted-key id='7c25280eae63ebe5' group='org.apache.httpcomponents' />
     <trusted-key id='1de461528f1f1b2a' group='org.apache.jackrabbit' />

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -55,6 +55,7 @@ ext {
     koloboke: '1.0.0',
     nullaway: '0.7.9',
     ohc: '0.6.1',
+    osgiComponentAnnotations: '1.4.0',
     picocli: '4.5.0',
     slf4j: '1.7.30',
     tcache: '2.0.1',
@@ -74,6 +75,10 @@ ext {
     paxExam: '4.13.3',
     testng: '7.3.0',
     truth: '0.24',
+    felix: '6.0.3',
+    felixScr: '2.1.20',
+    osgiUtilFunction: '1.1.0',
+    osgiUtilPromise: '1.1.0'
   ]
   pluginVersions = [
     apt: '0.21',
@@ -133,6 +138,7 @@ ext {
     ],
     nullaway: "com.uber.nullaway:nullaway:${versions.nullaway}",
     ohc: "org.caffinitas.ohc:ohc-core-j8:${versions.ohc}",
+    osgiComponentAnnotations: "org.osgi:org.osgi.service.component.annotations:${versions.osgiComponentAnnotations}",
     picocli: "info.picocli:picocli:${versions.picocli}",
     slf4jNop: "org.slf4j:slf4j-nop:${versions.slf4j}",
     tcache: "com.trivago:triava:${versions.tcache}",
@@ -156,10 +162,13 @@ ext {
     junit: "junit:junit:${testVersions.junit}",
     mockito: "org.mockito:mockito-core:${testVersions.mockito}",
     osgiCompile: [
-      'org.apache.felix:org.apache.felix.framework:6.0.3',
       "org.ops4j.pax.exam:pax-exam-junit4:${testVersions.paxExam}",
     ],
     osgiRuntime: [
+      "org.apache.felix:org.apache.felix.framework:${testVersions.felix}",
+      "org.apache.felix:org.apache.felix.scr:${testVersions.felixScr}",
+      "org.osgi:org.osgi.util.function:${testVersions.osgiUtilFunction}",
+      "org.osgi:org.osgi.util.promise:${testVersions.osgiUtilPromise}",
       "org.ops4j.pax.exam:pax-exam-container-native:${testVersions.paxExam}",
       "org.ops4j.pax.exam:pax-exam-link-mvn:${testVersions.paxExam}",
       "org.ops4j.pax.url:pax-url-aether:2.6.2",

--- a/jcache/build.gradle
+++ b/jcache/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   api libraries.jcache
   api libraries.config
   api libraries.jsr330
+  api libraries.osgiComponentAnnotations
 
   testImplementation libraries.guava
   testImplementation testLibraries.junit
@@ -32,16 +33,16 @@ dependencies {
 jar.manifest {
   attributes 'Bundle-SymbolicName': 'com.github.ben-manes.caffeine.jcache'
   attributes 'Import-Package': [
-    'javax.cache.*',
-    'javax.management',
-    'com.typesafe.config',
-    'com.github.benmanes.caffeine.cache',
-    'com.github.benmanes.caffeine.cache.stats'].join(',')
+    '!org.checkerframework.checker.*',
+    '*'].join(',')
   attributes 'Export-Package': [
     'com.github.benmanes.caffeine.jcache.spi',
     'com.github.benmanes.caffeine.jcache.copy',
     'com.github.benmanes.caffeine.jcache.configuration'].join(',')
   attributes 'Automatic-Module-Name': 'com.github.benmanes.caffeine.jcache'
+  attributes '-exportcontents': '${removeall;${packages;VERSIONED};${packages;CONDITIONAL}}'
+  attributes '-snapshot': 'SNAPSHOT'
+  attributes '-noextraheaders': true
 }
 
 task unzipJCacheJavaDoc(type: Copy, group: 'Build', description: 'Unzips the JCache JavaDoc') {
@@ -87,6 +88,10 @@ task osgiTests(type: Test, group: 'Build', description: 'Isolated OSGi tests') {
   tasks.test.dependsOn(it)
   systemProperty 'config.osgi.version', versions.config
   systemProperty 'jcache.osgi.version', versions.jcache
+  systemProperty 'checkerAnnotations.version', versions.checkerFramework
+  systemProperty 'felixScr.version', testVersions.felixScr
+  systemProperty 'osgiUtil.function', testVersions.osgiUtilFunction
+  systemProperty 'osgiUtil.promise', testVersions.osgiUtilPromise
   systemProperty 'caffeine.osgi.jar', project(':caffeine').jar.archivePath.path
   systemProperty 'caffeine-jcache.osgi.jar', project(':jcache').jar.archivePath.path
 }

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
@@ -33,6 +33,8 @@ import javax.cache.spi.CachingProvider;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider;
+
 /**
  * An implementation of JSR-107 {@link CacheManager} that manages Caffeine-based caches.
  *
@@ -45,6 +47,7 @@ public final class CacheManagerImpl implements CacheManager {
   private final CachingProvider cacheProvider;
   private final Properties properties;
   private final URI uri;
+  private final boolean runsAsAnOsgiBundle;
 
   private volatile boolean closed;
 
@@ -55,6 +58,8 @@ public final class CacheManagerImpl implements CacheManager {
     this.properties = requireNonNull(properties);
     this.caches = new ConcurrentHashMap<>();
     this.uri = requireNonNull(uri);
+    runsAsAnOsgiBundle =
+            cacheProvider instanceof CaffeineCachingProvider && ((CaffeineCachingProvider) cacheProvider).isOsgiComponent();
   }
 
   @Override
@@ -80,63 +85,90 @@ public final class CacheManagerImpl implements CacheManager {
   @Override
   public <K, V, C extends Configuration<K, V>> Cache<K, V> createCache(
       String cacheName, C configuration) {
-    requireNotClosed();
-    requireNonNull(configuration);
-
-    CacheProxy<?, ?> cache = caches.compute(cacheName, (name, existing) -> {
-      if ((existing != null) && !existing.isClosed()) {
-        throw new CacheException("Cache " + cacheName + " already exists");
-      } else if (CacheFactory.isDefinedExternally(cacheName)) {
-        throw new CacheException("Cache " + cacheName + " is configured externally");
+    ClassLoader old = Thread.currentThread().getContextClassLoader();
+    try {
+      if (runsAsAnOsgiBundle) {
+        // override the context class loader with the CachingManager's classloader
+        Thread.currentThread().setContextClassLoader(getClassLoader());
       }
-      return CacheFactory.createCache(this, cacheName, configuration);
-    });
-    enableManagement(cache.getName(), cache.getConfiguration().isManagementEnabled());
-    enableStatistics(cache.getName(), cache.getConfiguration().isStatisticsEnabled());
+      requireNotClosed();
+      requireNonNull(configuration);
 
-    @SuppressWarnings("unchecked")
-    Cache<K, V> castedCache = (Cache<K, V>) cache;
-    return castedCache;
+      CacheProxy<?, ?> cache = caches.compute(cacheName, (name, existing) -> {
+        if ((existing != null) && !existing.isClosed()) {
+          throw new CacheException("Cache " + cacheName + " already exists");
+        } else if (CacheFactory.isDefinedExternally(cacheName)) {
+          throw new CacheException("Cache " + cacheName + " is configured externally");
+        }
+        return CacheFactory.createCache(this, cacheName, configuration);
+      });
+      enableManagement(cache.getName(), cache.getConfiguration().isManagementEnabled());
+      enableStatistics(cache.getName(), cache.getConfiguration().isStatisticsEnabled());
+
+      @SuppressWarnings("unchecked")
+      Cache<K, V> castedCache = (Cache<K, V>) cache;
+      return castedCache;
+    } finally {
+      Thread.currentThread().setContextClassLoader(old);
+    }
   }
 
   @Override
   public @Nullable <K, V> Cache<K, V> getCache(
       String cacheName, Class<K> keyType, Class<V> valueType) {
-    CacheProxy<K, V> cache = getCache(cacheName);
-    if (cache == null) {
-      return null;
-    }
-    requireNonNull(keyType);
-    requireNonNull(valueType);
+    ClassLoader old = Thread.currentThread().getContextClassLoader();
+    try {
+      if (runsAsAnOsgiBundle) {
+        // override the context class loader with the CachingManager's classloader
+        Thread.currentThread().setContextClassLoader(getClassLoader());
+      }
+      CacheProxy<K, V> cache = getCache(cacheName);
+      if (cache == null) {
+        return null;
+      }
+      requireNonNull(keyType);
+      requireNonNull(valueType);
 
-    Configuration<?, ?> config = cache.getConfiguration();
-    if (keyType != config.getKeyType()) {
-      throw new ClassCastException("Incompatible cache key types specified, expected " +
-          config.getKeyType() + " but " + keyType + " was specified");
-    } else if (valueType != config.getValueType()) {
-      throw new ClassCastException("Incompatible cache value types specified, expected " +
-          config.getValueType() + " but " + valueType + " was specified");
+      Configuration<?, ?> config = cache.getConfiguration();
+      if (keyType != config.getKeyType()) {
+        throw new ClassCastException("Incompatible cache key types specified, expected " +
+                config.getKeyType() + " but " + keyType + " was specified");
+      } else if (valueType != config.getValueType()) {
+        throw new ClassCastException("Incompatible cache value types specified, expected " +
+                config.getValueType() + " but " + valueType + " was specified");
+      }
+      return cache;
+    } finally {
+      Thread.currentThread().setContextClassLoader(old);
     }
-    return cache;
   }
 
   @Override
   public <K, V> CacheProxy<K, V> getCache(String cacheName) {
-    requireNonNull(cacheName);
-    requireNotClosed();
-
-    CacheProxy<?, ?> cache = caches.computeIfAbsent(cacheName, name -> {
-      CacheProxy<?, ?> created = CacheFactory.tryToCreateFromExternalSettings(this, name);
-      if (created != null) {
-        created.enableManagement(created.getConfiguration().isManagementEnabled());
-        created.enableStatistics(created.getConfiguration().isStatisticsEnabled());
+    ClassLoader old = Thread.currentThread().getContextClassLoader();
+    try {
+      if (runsAsAnOsgiBundle) {
+        // override the context class loader with the CachingManager's classloader
+        Thread.currentThread().setContextClassLoader(getClassLoader());
       }
-      return created;
-    });
+      requireNonNull(cacheName);
+      requireNotClosed();
 
-    @SuppressWarnings("unchecked")
-    CacheProxy<K, V> castedCache = (CacheProxy<K, V>) cache;
-    return castedCache;
+      CacheProxy<?, ?> cache = caches.computeIfAbsent(cacheName, name -> {
+        CacheProxy<?, ?> created = CacheFactory.tryToCreateFromExternalSettings(this, name);
+        if (created != null) {
+          created.enableManagement(created.getConfiguration().isManagementEnabled());
+          created.enableStatistics(created.getConfiguration().isStatisticsEnabled());
+        }
+        return created;
+      });
+
+      @SuppressWarnings("unchecked")
+      CacheProxy<K, V> castedCache = (CacheProxy<K, V>) cache;
+      return castedCache;
+    } finally {
+      Thread.currentThread().setContextClassLoader(old);
+    }
   }
 
   @Override

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/OSGiTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/OSGiTest.java
@@ -15,6 +15,8 @@
  */
 package com.github.benmanes.caffeine.jcache;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
@@ -24,6 +26,7 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 import javax.cache.Cache;
 import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
+import javax.inject.Inject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,12 +36,17 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerMethod;
 
+import com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider;
+
 /**
  * @author ben.manes@gmail.com (Ben Manes)
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
 public final class OSGiTest {
+
+  @Inject
+  private CachingProvider cachingProvider;
 
   @Configuration
   public Option[] config() {
@@ -47,7 +55,10 @@ public final class OSGiTest {
         bundle("file:" + System.getProperty("caffeine.osgi.jar")),
         bundle("file:" + System.getProperty("caffeine-jcache.osgi.jar")),
         mavenBundle("com.typesafe", "config", System.getProperty("config.osgi.version")),
-        mavenBundle("javax.cache", "cache-api", System.getProperty("jcache.osgi.version")));
+        mavenBundle("javax.cache", "cache-api", System.getProperty("jcache.osgi.version")),
+        mavenBundle("org.apache.felix", "org.apache.felix.scr", System.getProperty("felixScr.version")),
+        mavenBundle().groupId("org.osgi").artifactId("org.osgi.util.function").version(System.getProperty("osgiUtil.function")),
+        mavenBundle().groupId("org.osgi").artifactId("org.osgi.util.promise").version(System.getProperty("osgiUtil.promise")));
   }
 
   @Test
@@ -58,5 +69,11 @@ public final class OSGiTest {
     Cache<String, Integer> cache = cachingProvider.getCacheManager()
         .getCache("test-cache-2", String.class, Integer.class);
     assertNull(cache.get("a"));
+  }
+
+  @Test
+  public void testOSGIDS() {
+    assertNotNull("Should have found a registered CachingProvider.", cachingProvider);
+    assertEquals(CaffeineCachingProvider.class, cachingProvider.getClass());
   }
 }


### PR DESCRIPTION
* annotated CaffeineCachingProvider to make it an OSGi service
* when running in an OSGi container, set the CaffeineCachingProvider's classloader as the Thread context classloader for every API call on the provided CacheManagerImpl - this makes sure that the default config is read from the bundle; the default classloader will do a fallback to the app classloader, allowing to override / define configurations
* added an OSGi DS test
* made the bnd build reproducible (no extra bundle headers)
(fixes #447)