### PR TITLE
Add an optional `Volatility` argument to `NodeRule#new{Getter|Setter}`.

### DIFF
--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddExpiration.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddExpiration.java
@@ -86,14 +86,14 @@ public final class AddExpiration extends NodeRule {
   private void addVariableTime(String varName) {
     MethodSpec getter = MethodSpec.methodBuilder("getVariableTime")
         .addModifiers(Modifier.PUBLIC)
-        .addStatement("return $T.UNSAFE.getLong(this, $N)",
+        .addStatement("return $T.UNSAFE.getLongVolatile(this, $N)",
             UNSAFE_ACCESS, offsetName(varName))
         .returns(long.class)
         .build();
     MethodSpec setter = MethodSpec.methodBuilder("setVariableTime")
         .addModifiers(Modifier.PUBLIC)
         .addParameter(long.class, varName)
-        .addStatement("$T.UNSAFE.putLong(this, $N, $N)",
+        .addStatement("$T.UNSAFE.putLongVolatile(this, $N, $N)",
             UNSAFE_ACCESS, offsetName(varName), varName)
         .build();
     MethodSpec cas = MethodSpec.methodBuilder("casVariableTime")
@@ -116,8 +116,10 @@ public final class AddExpiration extends NodeRule {
     }
     context.nodeSubtype.addField(newFieldOffset(context.className, "accessTime"))
         .addField(long.class, "accessTime", Modifier.VOLATILE)
-        .addMethod(newGetter(Strength.STRONG, TypeName.LONG, "accessTime", Visibility.LAZY))
-        .addMethod(newSetter(TypeName.LONG, "accessTime", Visibility.LAZY));
+        .addMethod(
+            newGetter(Strength.STRONG, TypeName.LONG, "accessTime", Visibility.LAZY,
+                Volatility.VOLATILE))
+        .addMethod(newSetter(TypeName.LONG, "accessTime", Visibility.LAZY, Volatility.VOLATILE));
     addTimeConstructorAssignment(context.constructorByKey, "accessTime");
     addTimeConstructorAssignment(context.constructorByKeyRef, "accessTime");
   }
@@ -127,8 +129,10 @@ public final class AddExpiration extends NodeRule {
         && Feature.useWriteTime(context.generateFeatures)) {
       context.nodeSubtype.addField(newFieldOffset(context.className, "writeTime"))
           .addField(long.class, "writeTime", Modifier.VOLATILE)
-          .addMethod(newGetter(Strength.STRONG, TypeName.LONG, "writeTime", Visibility.LAZY))
-          .addMethod(newSetter(TypeName.LONG, "writeTime", Visibility.LAZY));
+          .addMethod(
+              newGetter(Strength.STRONG, TypeName.LONG, "writeTime", Visibility.LAZY,
+                  Volatility.VOLATILE))
+          .addMethod(newSetter(TypeName.LONG, "writeTime", Visibility.LAZY, Volatility.VOLATILE));
       addTimeConstructorAssignment(context.constructorByKey, "writeTime");
       addTimeConstructorAssignment(context.constructorByKeyRef, "writeTime");
     }

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddValue.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/AddValue.java
@@ -68,11 +68,11 @@ public final class AddValue extends NodeRule {
         .addParameter(vRefQueueType, "referenceQueue");
 
     if (isStrongValues()) {
-      setter.addStatement("$T.UNSAFE.putObject(this, $N, $N)",
+      setter.addStatement("$T.UNSAFE.putObjectVolatile(this, $N, $N)",
           UNSAFE_ACCESS, offsetName("value"), "value");
     } else {
       setter.addStatement("(($T<V>) getValueReference()).clear()", Reference.class);
-      setter.addStatement("$T.UNSAFE.putObject(this, $N, new $T($L, $N, referenceQueue))",
+      setter.addStatement("$T.UNSAFE.putObjectVolatile(this, $N, new $T($L, $N, referenceQueue))",
           UNSAFE_ACCESS, offsetName("value"), valueReferenceType(), "getKeyReference()", "value");
     }
 


### PR DESCRIPTION
By default, `Volatility.NON_VOLATILE` is used.

Tested by manually inspecting the generated sources.

#446 