### PR TITLE
BoundedLocalCache Refactoring for Eviction abstractions

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/AbstractLinkedDeque.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/AbstractLinkedDeque.java
@@ -340,6 +340,10 @@ abstract class AbstractLinkedDeque<E> extends AbstractCollection<E> implements L
     return removeFirst();
   }
 
+  public final PeekingIterator<E> iterator(boolean ascending) {
+    return ascending ? iterator() : descendingIterator();
+  }
+
   @Override
   public PeekingIterator<E> iterator() {
     return new AbstractLinkedIterator(first) {


### PR DESCRIPTION
Abstracts the eviction candidate/victim heuristic.  it's still hardcoded in this commit with a "sketch frequency divided by node weight" experiment - but it's where a new interface or extension to Weigher could support custom impls provided in CacheBuilder.

Also :boom: Remapping and Eviction inner classes replace some Map-method lambdas that relied on many 1-element-array local variables.

Other misc refactoring that a line-by-line diff should explain

:warning: Unit tests *seem* to be intact.