### PR TITLE
Add 'record-native-stats' option to jcache configuration.

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
@@ -160,7 +160,7 @@ final class CacheFactory {
       evicts |= configureExpireAfterAccess();
       evicts |= configureExpireVariably();
 
-      if (config.isRecordNativeStats()) {
+      if (config.isNativeStatistics()) {
         caffeine.recordStats();
       }
 

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
@@ -160,6 +160,10 @@ final class CacheFactory {
       evicts |= configureExpireAfterAccess();
       evicts |= configureExpireVariably();
 
+      if (config.isRecordNativeStats()) {
+        caffeine.recordStats();
+      }
+
       JCacheEvictionListener<K, V> evictionListener = null;
       if (evicts) {
         evictionListener = new JCacheEvictionListener<>(dispatcher, statistics);

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/CaffeineConfiguration.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/CaffeineConfiguration.java
@@ -68,6 +68,7 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
   private @Nullable Long expireAfterWriteNanos;
   private @Nullable Long maximumWeight;
   private @Nullable Long maximumSize;
+  private boolean recordNativeStats;
 
   public CaffeineConfiguration() {
     delegate = new MutableConfiguration<>();
@@ -91,6 +92,7 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
       weigherFactory = config.weigherFactory;
       maximumWeight = config.maximumWeight;
       maximumSize = config.maximumSize;
+      recordNativeStats = config.recordNativeStats;
     } else {
       tickerFactory = SYSTEM_TICKER;
       executorFactory = COMMON_POOL;
@@ -385,6 +387,24 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
     return (maximumSize == null)
         ? OptionalLong.empty()
         : OptionalLong.of(maximumSize);
+  }
+
+  /**
+   * Enables native statistics collection.  Default is false.
+   *
+   * @param recordNativeStats whether to enable
+   */
+  public void setRecordNativeStats(boolean recordNativeStats) {
+    this.recordNativeStats = recordNativeStats;
+  }
+
+  /**
+   * Returns whether native statistics collection is enabled.
+   *
+   * @return enabled status
+   */
+  public boolean isRecordNativeStats() {
+    return recordNativeStats;
   }
 
   /**

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/CaffeineConfiguration.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/CaffeineConfiguration.java
@@ -68,7 +68,7 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
   private @Nullable Long expireAfterWriteNanos;
   private @Nullable Long maximumWeight;
   private @Nullable Long maximumSize;
-  private boolean recordNativeStats;
+  private boolean nativeStatistics;
 
   public CaffeineConfiguration() {
     delegate = new MutableConfiguration<>();
@@ -92,7 +92,7 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
       weigherFactory = config.weigherFactory;
       maximumWeight = config.maximumWeight;
       maximumSize = config.maximumSize;
-      recordNativeStats = config.recordNativeStats;
+      nativeStatistics = config.nativeStatistics;
     } else {
       tickerFactory = SYSTEM_TICKER;
       executorFactory = COMMON_POOL;
@@ -226,6 +226,24 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
   /** See {@link MutableConfiguration#setManagementEnabled}. */
   public void setManagementEnabled(boolean enabled) {
     delegate.setManagementEnabled(enabled);
+  }
+
+  /**
+   * Enables native statistics collection.  Default is false.
+   *
+   * @param nativeStatistics whether to enable
+   */
+  public void setNativeStatistics(boolean nativeStatistics) {
+    this.nativeStatistics = nativeStatistics;
+  }
+
+  /**
+   * Returns whether native statistics collection is enabled.
+   *
+   * @return enabled status
+   */
+  public boolean isNativeStatistics() {
+    return nativeStatistics;
   }
 
   /**
@@ -387,24 +405,6 @@ public final class CaffeineConfiguration<K, V> implements CompleteConfiguration<
     return (maximumSize == null)
         ? OptionalLong.empty()
         : OptionalLong.of(maximumSize);
-  }
-
-  /**
-   * Enables native statistics collection.  Default is false.
-   *
-   * @param recordNativeStats whether to enable
-   */
-  public void setRecordNativeStats(boolean recordNativeStats) {
-    this.recordNativeStats = recordNativeStats;
-  }
-
-  /**
-   * Returns whether native statistics collection is enabled.
-   *
-   * @return enabled status
-   */
-  public boolean isRecordNativeStats() {
-    return recordNativeStats;
   }
 
   /**

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
@@ -159,6 +159,7 @@ public final class TypesafeConfigurator {
       addEagerExpiration();
       addRefresh();
       addMaximum();
+      addRecordStats();
 
       return configuration;
     }
@@ -299,6 +300,13 @@ public final class TypesafeConfigurator {
       if (isSet("policy.maximum.weigher")) {
         configuration.setWeigherFactory(Optional.of(
             FactoryBuilder.factoryOf(merged.getString("policy.maximum.weigher"))));
+      }
+    }
+
+    /** Adds whether we are recording native stats. */
+    private void addRecordStats() {
+      if (isSet("record-native-stats")) {
+        configuration.setRecordNativeStats(merged.getBoolean("record-native-stats"));
       }
     }
 

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
@@ -159,7 +159,6 @@ public final class TypesafeConfigurator {
       addEagerExpiration();
       addRefresh();
       addMaximum();
-      addRecordStats();
 
       return configuration;
     }
@@ -230,10 +229,11 @@ public final class TypesafeConfigurator {
       }
     }
 
-    /** Adds the JMX monitoring settings. */
+    /** Adds the JMX monitoring settings and native statistics setting. */
     private void addMonitoring() {
       configuration.setStatisticsEnabled(merged.getBoolean("monitoring.statistics"));
       configuration.setManagementEnabled(merged.getBoolean("monitoring.management"));
+      configuration.setNativeStatistics(merged.getBoolean("monitoring.native-statistics"));
     }
 
     /** Adds the JCache specification's lazy expiration settings. */
@@ -300,13 +300,6 @@ public final class TypesafeConfigurator {
       if (isSet("policy.maximum.weigher")) {
         configuration.setWeigherFactory(Optional.of(
             FactoryBuilder.factoryOf(merged.getString("policy.maximum.weigher"))));
-      }
-    }
-
-    /** Adds whether we are recording native stats. */
-    private void addRecordStats() {
-      if (isSet("record-native-stats")) {
-        configuration.setRecordNativeStats(merged.getBoolean("record-native-stats"));
       }
     }
 

--- a/jcache/src/main/resources/reference.conf
+++ b/jcache/src/main/resources/reference.conf
@@ -53,6 +53,9 @@ caffeine.jcache {
 
       # If the configuration should be externalized
       management = false
+
+      # If native (caffeine) statistics should be enabled on the underlying caches
+      native-statistics = false
     }
 
     # The eviction policy for automatically removing entries from the cache

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurationTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurationTest.java
@@ -84,7 +84,7 @@ public final class TypesafeConfigurationTest {
     assertThat(config2.get().getKeyType(), is(String.class));
     assertThat(config2.get().getValueType(), is(Integer.class));
     assertThat(config2.get().getExecutorFactory().create(), is(ForkJoinPool.commonPool()));
-    assertThat(config2.get().isRecordNativeStats(), is(false));
+    assertThat(config2.get().isNativeStatistics(), is(false));
   }
 
   @Test
@@ -110,7 +110,7 @@ public final class TypesafeConfigurationTest {
     assertThat(config.getCacheWriter(), is(instanceOf(TestCacheWriter.class)));
     assertThat(config.isStatisticsEnabled(), is(true));
     assertThat(config.isManagementEnabled(), is(true));
-    assertThat(config.isRecordNativeStats(), is(true));
+    assertThat(config.isNativeStatistics(), is(true));
 
     checkSize(config);
     checkRefresh(config);

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurationTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurationTest.java
@@ -84,6 +84,7 @@ public final class TypesafeConfigurationTest {
     assertThat(config2.get().getKeyType(), is(String.class));
     assertThat(config2.get().getValueType(), is(Integer.class));
     assertThat(config2.get().getExecutorFactory().create(), is(ForkJoinPool.commonPool()));
+    assertThat(config2.get().isRecordNativeStats(), is(false));
   }
 
   @Test
@@ -109,6 +110,7 @@ public final class TypesafeConfigurationTest {
     assertThat(config.getCacheWriter(), is(instanceOf(TestCacheWriter.class)));
     assertThat(config.isStatisticsEnabled(), is(true));
     assertThat(config.isManagementEnabled(), is(true));
+    assertThat(config.isRecordNativeStats(), is(true));
 
     checkSize(config);
     checkRefresh(config);

--- a/jcache/src/test/resources/application.conf
+++ b/jcache/src/test/resources/application.conf
@@ -6,7 +6,6 @@ caffeine.jcache {
 
   test-cache {
     store-by-value.enabled = true
-    record-native-stats = true
     
     executor = com.github.benmanes.caffeine.jcache.configuration.TestExecutor
 
@@ -25,6 +24,7 @@ caffeine.jcache {
     monitoring {
       statistics = true
       management = true
+      native-statistics = true
     }
 
     policy {

--- a/jcache/src/test/resources/application.conf
+++ b/jcache/src/test/resources/application.conf
@@ -6,6 +6,7 @@ caffeine.jcache {
 
   test-cache {
     store-by-value.enabled = true
+    record-native-stats = true
     
     executor = com.github.benmanes.caffeine.jcache.configuration.TestExecutor
 


### PR DESCRIPTION
When true, this enables stats collection (Caffeine.recordStats() on
the underlying caches.  These caches can then be registered with
micrometer and, imo, are more useful than the Jcache metrics.

PS:  The CLA link in contributing.md is broken.