### PR TITLE
Verify maximumWeight before setting

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
@@ -407,8 +407,8 @@ public final class Caffeine<K, V> {
         "maximum weight was already set to %s", this.maximumWeight);
     requireState(this.maximumSize == UNSET_INT,
         "maximum size was already set to %s", this.maximumSize);
-    this.maximumWeight = maximumWeight;
     requireArgument(maximumWeight >= 0, "maximum weight must not be negative");
+    this.maximumWeight = maximumWeight;
     return this;
   }
 


### PR DESCRIPTION
The `maximumWeight` builder method is the only method that does the argument verification before the assignment.
It looks like a typo, and does not affect anyone in practice, but it is still better to have the implementation uniform.