### PR TITLE
Add ClockProPlus policy

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/Registry.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/Registry.java
@@ -32,6 +32,7 @@ import com.github.benmanes.caffeine.cache.simulator.policy.adaptive.ArcPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.adaptive.CarPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.adaptive.CartPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.irr.ClockProPolicy;
+import com.github.benmanes.caffeine.cache.simulator.policy.irr.ClockProPlusPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.irr.DClockPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.irr.FrdPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.irr.HillClimberFrdPolicy;
@@ -176,6 +177,7 @@ public final class Registry {
 
     factories.put("irr.Lirs", LirsPolicy::policies);
     factories.put("irr.ClockPro", ClockProPolicy::policies);
+    factories.put("irr.ClockProPlus", ClockProPlusPolicy::policies);
 
     factories.put("irr.DClock", DClockPolicy::policies);
   }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPlusPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPlusPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Ben Manes. All Rights Reserved.
+ * Copyright 2020 Ben Manes. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,41 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
- * The ClockPro algorithm. This algorithm differs from LIRS by replacing the LRU stacks with Clock
- * (Second Chance) policy. This allows cache hits to be performed concurrently at the cost of a
- * global lock on a miss and a worst case O(n) eviction when the queue is scanned.
- * <p>
- * ClockPro uses three hands that scan the queue. The hot hand points to the largest recency, the
- * cold hand to the cold entry furthest from the hot hand, and the test hand to the last cold entry
- * in the test period. This policy is adaptive by adjusting the percentage of hot and cold entries
- * that may reside in the cache. It uses non-resident (ghost) entries to retain additional history,
- * which are removed during the test hand's scan. The algorithm is explained by the authors in
- * <a href="http://www.ece.eng.wayne.edu/~sjiang/pubs/papers/jiang05_CLOCK-Pro.pdf">CLOCK-Pro: An
- * Effective Improvement of the CLOCK Replacement</a> and
- * <a href="http://www.slideshare.net/huliang64/clockpro">Clock-Pro: An Effective Replacement in OS
- * Kernel</a>.
+ * The ClockProPlus algorithm. This algorithm differs from ClockPro by adjusting the coldTarget
+ * with the utility-driven adaption idea borrowed from CAR. The algorithm is explained by the
+ * authors in <a href="https://dl.acm.org/doi/10.1145/3319647.3325838">CLOCK-Pro+: improving
+ * CLOCK-Pro cache replacement with utility-driven adaptation</a>.
+ *
+ * Implementation here differs from ClockProPolicy only in adjusting coldTarget and tracking for
+ * demoted status part. Below is a summarize of coldTarget adjusting differences between ClockPro
+ * and ClockPro+.
+ * +-----------------------------------------------------------------------------------+
+ * |                  ClockPro ColdTarget Adaption Algorithm Summary                   |
+ * +------+----------+-----------------------------------------------------------------+
+ * | When | increase |                                     access in test period pages |
+ * |      | decrease |                           test period is expired without access |
+ * +------+----------+-----------------------------------------------------------------+
+ * | Size | increase |                                                              +1 |
+ * |      | decrease |                                                              -1 |
+ * +------+----------+-----------------------------------------------------------------+
+ * |                  ClockPro+ ColdTarget Adaption Algorithm Summary                  |
+ * +------+----------+-----------------------------------------------------------------+
+ * | When | increase |                                    access in non-resident pages |
+ * |      | decrease |                                access in demoted from hot pages |
+ * |      |          |  * Note: demoted from hot pages ⊂ resident cold but not in test |
+ * +------+----------+-----------------------------------------------------------------+
+ * | Size | increase |         d = (demoted size / non-resident size); d < 1 ? +1 : +d |
+ * |      | decrease |         d = (non-resident size / demoted size); d < 1 ? -1 : -d |
+ * +------+----------+-----------------------------------------------------------------+
+ *
+ * This algorithm uses non-resident cold entries size to calculate adaption size so changing
+ * non-resident-multiplier may affect the adaption algorithm. In the author's research code
+ * percent-max-resident-cold was set to 0.5x.
  *
  * @author ben.manes@gmail.com (Ben Manes)
  * @author park910113@gmail.com (Chanyoung Park)
  */
-public final class ClockProPolicy implements KeyOnlyPolicy {
+public final class ClockProPlusPolicy implements KeyOnlyPolicy {
   private final Long2ObjectMap<Node> data;
   private final PolicyStats policyStats;
 
@@ -80,10 +97,11 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
   private int sizeNonResCold;
   private int sizeInTest;
   private int sizeFree;
+  private int sizeDemoted;
 
   // Target number of resident cold pages (adaptive):
-  //  - increases when test page gets a hit
-  //  - decreases when test page is removed
+  //  - increases when non-resident page gets a hit
+  //  - decreases when demoted cold page gets a hit
   private int coldTarget;
   // {min,max}ResColdSize are boundary of coldTarget.
   private int minResColdSize;
@@ -92,8 +110,8 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
   // Enable to print out the internal state
   static final boolean debug = false;
 
-  public ClockProPolicy(Config config) {
-    ClockProSettings settings = new ClockProSettings(config);
+  public ClockProPlusPolicy(Config config) {
+    ClockProPlusSettings settings = new ClockProPlusSettings(config);
     this.maxSize = Ints.checkedCast(settings.maximumSize());
     this.maxNonResSize = (int) (maxSize * settings.nonResidentMultiplier());
     this.minResColdSize = (int) (maxSize * settings.percentMinCold());
@@ -104,7 +122,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     if (maxResColdSize > maxSize - minResColdSize) {
       maxResColdSize = maxSize - minResColdSize;
     }
-    this.policyStats = new PolicyStats("irr.ClockPro");
+    this.policyStats = new PolicyStats("irr.ClockProPlus");
     this.data = new Long2ObjectOpenHashMap<>();
     this.coldTarget = minResColdSize;
     this.listHead = this.handHot = this.handCold = this.handTest = null;
@@ -116,7 +134,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
    * Returns all variations of this policy based on the configuration parameters.
    */
   public static Set<Policy> policies(Config config) {
-    return ImmutableSet.of(new ClockProPolicy(config));
+    return ImmutableSet.of(new ClockProPlusPolicy(config));
   }
 
   @Override
@@ -229,8 +247,10 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     if (!candidate.isInClock() || !candidate.isInTest()) {
       return false;
     }
-    // This candidate cold page is accessed during its test period, so we increment coldTarget by 1.
-    coldTargetAdjust(+1);
+    if (!candidate.isResident()) {
+      // If an access on a non-resident cold page then increment coldTarget.
+      coldTargetAdjust(true);
+    }
     while (sizeHot >= maxSize - coldTarget) {
       // handHot has passed the candidate and terminates its test period. Reject the promotion.
       if (!candidate.isInTest()) {
@@ -261,6 +281,12 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
           handCold.moveToHead(Status.COLD_RES_IN_TEST);
         }
       } else {
+        if (handCold.demoted) {
+          // Decrease cold target when observing the reference bit set on a demoted cold page.
+          handCold.demoted = false;
+          coldTargetAdjust(false);
+          sizeDemoted--;
+        }
         handCold.moveToHead(Status.COLD_RES_IN_TEST);
       }
     } else {
@@ -272,6 +298,10 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
         handCold.setStatus(Status.COLD_NON_RES);
         handCold = handCold.prev;
       } else {
+        if (handCold.demoted) {
+          handCold.demoted = false;
+          sizeDemoted--;
+        }
         handCold.removeFromClock();
       }
       // We keep track the number of non-resident cold pages. Once the number exceeds the limit, we
@@ -306,11 +336,19 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
         if (handHot.marked) {
           handHot.moveToHead(Status.HOT);
         } else {
+          handHot.demoted = true;
+          sizeDemoted++;
           handHot.moveToHead(Status.COLD_RES);
           demoted = true;
           break;
         }
       } else {
+        if (handHot.marked && handHot.demoted) {
+          // Decrease cold target when observing the reference bit set on a demoted cold page.
+          handHot.demoted = false;
+          coldTargetAdjust(false);
+          sizeDemoted--;
+        }
         // Whenever the hand encounters a cold page, it will terminate the page’s test period. The
         // hand will also remove the cold page from the clock if it is non-resident (the most
         // probable case). It actually does the work on the cold page on behalf of handTest.
@@ -339,12 +377,10 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     if (node.isResidentCold()) {
       node.setStatus(Status.COLD_RES);
     } else {
+      // Demoted node can't be in a test period.
+      checkState(!node.demoted);
       node.removeFromClock();
     }
-    // If a cold page is accessed during its test period, we increment coldTarget by 1. If a cold
-    // page passes its test period without a re-access, we decrement coldTarget by 1. Note the
-    // aforementioned cold pages include resident and non-resident cold pages.
-    coldTargetAdjust(node.marked ? +1 : -1);
   }
 
   // Make handCold points to the resident cold page with the largest recency.
@@ -399,6 +435,26 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     nextHandTest();
   }
 
+  private void coldTargetAdjust(boolean increase) {
+    int delta = 0;
+    if (increase) {
+      if (sizeNonResCold != 0) {
+        delta = sizeDemoted / sizeNonResCold;
+      }
+    } else {
+      if (sizeDemoted != 0) {
+        delta = sizeNonResCold / sizeDemoted;
+      }
+    }
+    if (delta < 1) {
+      delta = 1;
+    }
+    if (!increase) {
+      delta = delta * -1;
+    }
+    coldTargetAdjust(delta);
+  }
+
   private void coldTargetAdjust(int n) {
     coldTarget += n;
     if (coldTarget < minResColdSize) {
@@ -448,7 +504,8 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     int sizeResCold;
     int sizeNonResCold;
     int sizeInTest;
-    sizeHot = sizeInTest = sizeResCold = sizeNonResCold = 0;
+    int sizeRecentlyDemoted;
+    sizeHot = sizeInTest = sizeResCold = sizeNonResCold = sizeRecentlyDemoted = 0;
 
     Node node = listHead;
     do {
@@ -468,6 +525,9 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
       if (node.isInTest()) {
         sizeInTest++;
       }
+      if (node.demoted) {
+        sizeRecentlyDemoted++;
+      }
       node = node.next;
     } while (node != listHead);
 
@@ -475,6 +535,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     checkState(sizeNonResCold == this.sizeNonResCold);
     checkState(sizeInTest == this.sizeInTest);
     checkState(sizeResCold == this.sizeResCold);
+    checkState(sizeRecentlyDemoted == this.sizeDemoted);
     checkState(sizeHot + sizeResCold == maxSize - sizeFree);
     checkState(sizeResCold + sizeFree >= minResColdSize);
     checkState(sizeResCold <= maxResColdSize);
@@ -510,6 +571,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     Node next;
 
     boolean marked;
+    boolean demoted;
 
     public Node(long key) {
       this.key = key;
@@ -591,6 +653,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
       StringBuilder sb = new StringBuilder(MoreObjects.toStringHelper(this)
           .add("key", key)
           .add("marked", marked)
+          .add("demoted", demoted)
           .add("type", status)
           .toString());
       if (this == handHot) {
@@ -606,21 +669,21 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     }
   }
 
-  static final class ClockProSettings extends BasicSettings {
-    public ClockProSettings(Config config) {
+  static final class ClockProPlusSettings extends BasicSettings {
+    public ClockProPlusSettings(Config config) {
       super(config);
     }
     public int lowerBoundCold() {
-      return config().getInt("clockpro.lower-bound-resident-cold");
+      return config().getInt("clockproplus.lower-bound-resident-cold");
     }
     public double percentMinCold() {
-      return config().getDouble("clockpro.percent-min-resident-cold");
+      return config().getDouble("clockproplus.percent-min-resident-cold");
     }
     public double percentMaxCold() {
-      return config().getDouble("clockpro.percent-max-resident-cold");
+      return config().getDouble("clockproplus.percent-max-resident-cold");
     }
     public double nonResidentMultiplier() {
-      return config().getDouble("clockpro.non-resident-multiplier");
+      return config().getDouble("clockproplus.non-resident-multiplier");
     }
   }
 }

--- a/simulator/src/main/resources/reference.conf
+++ b/simulator/src/main/resources/reference.conf
@@ -87,6 +87,7 @@ caffeine.simulator {
     irr.Lirs,
     irr.DClock,
     irr.ClockPro,
+    irr.ClockProPlus,
 
     # Policies based on the FRD algorithm
     irr.Frd,
@@ -404,6 +405,17 @@ caffeine.simulator {
     percent-min-resident-cold = 0.01
     # The percentage for the maximum resident cold entries
     percent-max-resident-cold = 0.99
+    # The lower bound for the number of resident cold entries
+    lower-bound-resident-cold = 2
+    # The multiple of the maximum size dedicated to non-resident entries
+    non-resident-multiplier = 2.0
+  }
+
+  clockproplus {
+    # The percentage for the minimum resident cold entries
+    percent-min-resident-cold = 0.01
+    # The percentage for the maximum resident cold entries
+    percent-max-resident-cold = 0.5
     # The lower bound for the number of resident cold entries
     lower-bound-resident-cold = 2
     # The multiple of the maximum size dedicated to non-resident entries


### PR DESCRIPTION
- It seems dirty, but I just copied and pasted the ClockPro code and modified parts of adjusting coldTarget. This is because the noise issue still remaining in ClockPro algorithm, so I wanted to keep the code as easy as possible to modify and test without depending on other files.
- ClockPro's default configuration has been changed as we discussed