### PR TITLE
Add module descriptor while keeping workable Eclipse IDE experience

### DIFF
--- a/caffeine/build.gradle
+++ b/caffeine/build.gradle
@@ -24,7 +24,12 @@ idea.module {
 }
 
 eclipse.classpath.file.whenMerged {
-  entries.findAll { it instanceof SourceFolder && it.output == 'bin/codeGen' }*.output = 'bin/main'
+  entries.findAll {
+    it instanceof SourceFolder && it.output == 'bin/codeGen'
+  }*.output = 'bin/main'
+  // Exclude module-info when compiling through Eclipse
+  def main = entries.find { it instanceof SourceFolder && it.path == 'src/main/java' }
+  main.excludes.add('module-info.java')
 }
 
 plugins.withType(EclipsePlugin) {

--- a/caffeine/src/main/java/module-info.java
+++ b/caffeine/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.github.benmanes.caffeine {
+  exports com.github.benmanes.caffeine.cache;
+  exports com.github.benmanes.caffeine.cache.stats;
+
+  requires static transitive com.google.errorprone.annotations;
+  requires static transitive org.checkerframework.checker.qual;
+}

--- a/gradle/codeQuality.gradle
+++ b/gradle/codeQuality.gradle
@@ -148,7 +148,6 @@ tasks.withType(JavaCompile).configureEach {
       annotatedPackages.add('com.github.benmanes.caffeine')
     }
   }
-  modularity.inferModulePath.set(false)
   checkerFramework.skipCheckerFramework = true
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ ext {
     elasticSearch: '7.12.0',
     expiringMap: '0.5.9',
     fastfilter: '1.0',
-    fastutil: '8.5.4',
+    fastutil: '8.5.2',
     flipTables: '1.1.0',
     googleJavaFormat: '1.10.0',
     guava: '30.1.1-jre',
@@ -165,10 +165,14 @@ ext {
     jcacheTck: "javax.cache:cache-tests:${testVersions.jcacheTck}",
     jcacheTckTests: "javax.cache:cache-tests:${testVersions.jcacheTck}:tests",
     jctools: "org.jctools:jctools-core:${testVersions.jctools}",
-    junit: "junit:junit:${testVersions.junit}",
+    junit: dependencies.create("junit:junit:${testVersions.junit}") {
+      exclude group: 'org.hamcrest'
+    },
     mockito: "org.mockito:mockito-core:${testVersions.mockito}",
     osgiCompile: [
-      "org.ops4j.pax.exam:pax-exam-junit4:${testVersions.paxExam}",
+      dependencies.create("org.ops4j.pax.exam:pax-exam-junit4:${testVersions.paxExam}") {
+        exclude group: 'org.hamcrest'
+      },
     ],
     osgiRuntime: [
       "org.apache.felix:org.apache.felix.framework:${testVersions.felix}",

--- a/guava/build.gradle
+++ b/guava/build.gradle
@@ -14,6 +14,10 @@ dependencies {
   testImplementation testLibraries.guavaTestLib
 }
 
+compileJava {
+  modularity.inferModulePath = false
+}
+
 jar.manifest {
   attributes 'Bundle-SymbolicName': 'com.github.ben-manes.caffeine.guava'
   attributes 'Import-Package': [

--- a/jcache/build.gradle
+++ b/jcache/build.gradle
@@ -30,6 +30,10 @@ dependencies {
   doc "${libraries.jcache}:javadoc"
 }
 
+compileJava {
+  modularity.inferModulePath = false
+}
+
 jar.manifest {
   attributes 'Bundle-SymbolicName': 'com.github.ben-manes.caffeine.jcache'
   attributes 'Import-Package': [

--- a/simulator/build.gradle
+++ b/simulator/build.gradle
@@ -35,6 +35,10 @@ dependencies {
   testImplementation testLibraries.testng
 }
 
+compileJava {
+  modularity.inferModulePath = false
+}
+
 test {
   useTestNG()
 }


### PR DESCRIPTION
Considering it was noted that the module descriptor broke usage in Eclipse/buildship, I took care to ensure that Caffeine can still compile in Eclipse.

I developed and tested this solution using Eclipse 2021-03 (4.19.0). It relies on the Module Dependencies tab of the project build path menu to fix compilation in Eclipse/buildship.

Hamcrest v1 had to be excluded from transitive dependencies since it lead to a split package clash.

FastUtil had to be downgraded to 8.5.2 because of split packages: https://github.com/vigna/fastutil/issues/245

Resolves #535 