### PR TITLE
Update GDWheelPolicy.java

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GDWheelPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GDWheelPolicy.java
@@ -122,7 +122,7 @@ public final class GDWheelPolicy implements Policy {
     clockHand[level] = hand;
 
     // if C[idx] has advanced a whole round back to 1, call migration(idx+1)
-    if ((hand == 0) && (level < wheel.length)) {
+    if ((hand == 0) && (level + 1 < wheel.length)) {
       migrate(level + 1);
     }
 


### PR DESCRIPTION
A fix for null pointer in migrate.
changed the condition of the if statment as to not cause a null pointer exception by trying to access wheel at index that is out of bounds.