### PR TITLE
refactored StripedBuffer.java to reduce the methods cyclomatic complexity and renamed variables to give meaningful name to them

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/StripedBuffer.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/StripedBuffer.java
@@ -31,7 +31,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A base class providing the mechanics for supporting dynamic striping of bounded buffers. This
- * implementation is an adaption of the numeric 64-bit {@link java.util.concurrent.atomic.Striped64}
+ * implementation is an adaption of the numeric 64-bit { @link java.util.concurrent.atomic.Striped64 }
  * class, which is used by atomic counters. The approach was modified to lazily grow an array of
  * buffers in order to minimize memory usage for caches that are not heavily contended on.
  *
@@ -115,9 +115,11 @@ abstract class StripedBuffer<E> implements Buffer<E> {
 
   @Override
   public int offer(E e) {
-    long z = mix64(Thread.currentThread().getId());
-    int increment = (int) (z >>> 32) | 1;
-    int h = (int) z;
+    /* refactored variable name from z to threadID as z was not giving much information about its value */
+    long threadID = mix64(Thread.currentThread().getId());
+    int increment = (int) (threadID >>> 32) | 1;
+    /* refactored variable name from h to modifiedThreadID as h was not giving much information about its value */
+    int modifiedThreadID = (int) threadID;
 
     int mask;
     int result;
@@ -126,9 +128,9 @@ abstract class StripedBuffer<E> implements Buffer<E> {
     Buffer<E>[] buffers = table;
     if ((buffers == null)
         || ((mask = buffers.length - 1) < 0)
-        || ((buffer = buffers[h & mask]) == null)
+        || ((buffer = buffers[modifiedThreadID & mask]) == null)
         || !(uncontended = ((result = buffer.offer(e)) != Buffer.FAILED))) {
-      return expandOrRetry(e, h, increment, uncontended);
+      return expandOrRetry(e, modifiedThreadID, increment, uncontended);
     }
     return result;
   }
@@ -154,19 +156,8 @@ abstract class StripedBuffer<E> implements Buffer<E> {
       if (((buffers = table) != null) && ((n = buffers.length) > 0)) {
         if ((buffer = buffers[(n - 1) & h]) == null) {
           if ((tableBusy == 0) && casTableBusy()) { // Try to attach new Buffer
-            boolean created = false;
-            try { // Recheck under lock
-              Buffer<E>[] rs;
-              int mask, j;
-              if (((rs = table) != null) && ((mask = rs.length) > 0)
-                  && (rs[j = (mask - 1) & h] == null)) {
-                rs[j] = create(e);
-                created = true;
-              }
-            } finally {
-              tableBusy = 0;
-            }
-            if (created) {
+            /* Extracted implementation to a method to reduce the cyclomatic complexity and size for readability of this method */
+            if (isCreated(e, h)) {
               break;
             }
             continue; // Slot is now non-empty
@@ -193,24 +184,47 @@ abstract class StripedBuffer<E> implements Buffer<E> {
         }
         h += increment;
       } else if ((tableBusy == 0) && (table == buffers) && casTableBusy()) {
-        boolean init = false;
-        try { // Initialize table
-          if (table == buffers) {
-            @SuppressWarnings({"unchecked", "rawtypes"})
-            Buffer<E>[] rs = new Buffer[1];
-            rs[0] = create(e);
-            table = rs;
-            init = true;
-          }
-        } finally {
-          tableBusy = 0;
-        }
-        if (init) {
+        /* Extracted implementation to a method to reduce the cyclomatic complexity and size for readability of this method */
+        if (isInit(e, buffers)) {
           break;
         }
       }
     }
     return result;
+  }
+
+  /* Extracted method to reduce the cyclomatic complexity and size of the parent method */
+  private boolean isCreated(E e, int h) {
+    boolean created = false;
+    try { // Recheck under lock
+      Buffer<E>[] rs;
+      int mask, j;
+      if (((rs = table) != null) && ((mask = rs.length) > 0)
+          && (rs[j = (mask - 1) & h] == null)) {
+        rs[j] = create(e);
+        created = true;
+      }
+    } finally {
+      tableBusy = 0;
+    }
+    return created;
+  }
+
+  /* Extracted method to reduce the cyclomatic complexity and size of the parent method */
+  private boolean isInit(E e, Buffer<E> @Nullable [] buffers) {
+    boolean init = false;
+    try { // Initialize table
+      if (table == buffers) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Buffer<E>[] rs = new Buffer[1];
+        rs[0] = create(e);
+        table = rs;
+        init = true;
+      }
+    } finally {
+      tableBusy = 0;
+    }
+    return init;
   }
 
   @Override
@@ -257,10 +271,11 @@ abstract class StripedBuffer<E> implements Buffer<E> {
   }
 
   /** Computes Stafford variant 13 of 64-bit mix function. */
-  static long mix64(long z) {
-    z = (z ^ (z >>> 30)) * 0xbf58476d1ce4e5b9L;
-    z = (z ^ (z >>> 27)) * 0x94d049bb133111ebL;
-    return z ^ (z >>> 31);
+  /* refactored variable name from z to threadID as z was not giving much information about its value */
+  static long mix64(long threadID) {
+    threadID = (threadID ^ (threadID >>> 30)) * 0xbf58476d1ce4e5b9L;
+    threadID = (threadID ^ (threadID >>> 27)) * 0x94d049bb133111ebL;
+    return threadID ^ (threadID >>> 31);
   }
 
   static {


### PR DESCRIPTION
Hi,

I refactored **StripedBuffer.java** where the method **expandOrRetry** was bloating and was having high cyclomatic complexity. I refactored it by creating two new private methods **isCreated** and **isInit** that support the method. This reduced the size of the method by increasing the readability and understandability of the code.

I also refactored a few variables whose name was not appropriate for the context. For example, the variable **"z"** was not giving any contextual meaning hence I refactored it to **"threadID"**. The other variable **"h"** was also not giving the contextual meaning, hence refactored it to **"modifiedThreadID"**.

**Note:**
I have done this out of curiosity to learn how to contribute to open-source projects and as a part of my academic work. Hope this is useful.

Thanks,
Shiva.