### PR TITLE
Reorder the operation of reducing size before that of bulk loading

### DIFF
--- a/examples/coalescing-bulkloader/src/main/java/com/github/benmanes/caffeine/examples/coalescing/bulkloader/CoalescingBulkloader.java
+++ b/examples/coalescing-bulkloader/src/main/java/com/github/benmanes/caffeine/examples/coalescing/bulkloader/CoalescingBulkloader.java
@@ -202,8 +202,8 @@ public class CoalescingBulkloader<Key, Value> implements AsyncCacheLoader<Key, V
 
       final int taken = maxLoadSize - counter;
       if (taken > 0) {
-        bulkLoader.accept(toLoad);
         size.updateAndGet(oldSize -> oldSize - taken);
+        bulkLoader.accept(toLoad);
       }
 
     } while (size.get() >= maxLoadSize);


### PR DESCRIPTION
# Description

Bulk loading is expected to be a time-consuming operation. During bulk loading, other threads may invoke the method "doLoad" which is unnecessary, because the queue size is still larger than maxLoadSize. These threads will invoke "doLoad" immediately after finishing pervious "doLoad" but load nothing.

So moving the reduce-queue-size operation before the bulk-load operation will not cause the problem above.