### PR TITLE
Change Description of feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Caffeine provides flexible construction to create a cache with a combination of 
  * [size-based eviction][size] when a maximum is exceeded based on [frequency and recency][efficiency]
  * [time-based expiration][time] of entries, measured since last access or last write
  * [asynchronously refresh][refresh] when the first stale request for an entry occurs
- * keys automatically wrapped in [weak references][reference]
- * values automatically wrapped in [weak or soft references][reference]
+ * keys can be wrapped in [weak references][reference]
+ * values can be wrapped in [weak or soft references][reference]
  * [notification][listener] of evicted (or otherwise removed) entries
  * [writes propagated][compute] to an external resource
  * accumulation of cache access [statistics][statistics]


### PR DESCRIPTION
Hi @ben-manes 

Above documentation creates confusion, even I assumed that by default `key/value` are being wrapped with `WeakReference`.

The word `automatically` means, without any user intervention.
<img width="664" alt="Screenshot 2022-06-04 at 5 40 22 PM" src="https://user-images.githubusercontent.com/6632645/172010726-af055932-e307-49e3-bece-80d0edb2d186.png">

Due to above wording in documentation, sometimes it might lead to same confusion again.