### PR TITLE
Use initial capacity for linked hash set in getAllPresent()

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
@@ -23,6 +23,7 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.ConcurrentModificationException;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -138,6 +139,7 @@ import com.google.errorprone.annotations.FormatMethod;
 public final class Caffeine<K, V> {
   static final Logger logger = Logger.getLogger(Caffeine.class.getName());
   static final Supplier<StatsCounter> ENABLED_STATS_COUNTER_SUPPLIER = ConcurrentStatsCounter::new;
+  static final double DEFAULT_LOAD_FACTOR = 0.75;
 
   enum Strength { WEAK, SOFT }
   static final int UNSET_INT = -1;
@@ -212,6 +214,30 @@ public final class Caffeine<K, V> {
   static long ceilingPowerOfTwo(long x) {
     // From Hacker's Delight, Chapter 3, Harry S. Warren Jr.
     return 1L << -Long.numberOfLeadingZeros(x - 1);
+  }
+
+  /**
+   * Calculate initial capacity for {@link HashMap}-based classes, from expected size and default
+   * load factor (0.75).
+   *
+   * @param numMappings the expected number of mappings
+   * @return initial capacity for HashMap based classes
+   */
+  static int calculateHashMapCapacity(int numMappings) {
+    return (int) Math.ceil(numMappings / DEFAULT_LOAD_FACTOR);
+  }
+
+  /**
+   * Calculate initial capacity for {@link HashMap}-based classes, from expected size and default
+   * load factor (0.75).
+   *
+   * @param iterable the expected number of mappings
+   * @return initial capacity for HashMap based classes
+   */
+  static int calculateHashMapCapacity(Iterable<?> iterable) {
+    return (iterable instanceof Collection)
+        ? calculateHashMapCapacity(((Collection<?>) iterable).size())
+        : /* DEFAULT_INITIAL_CAPACITY */ 16;
   }
 
   /**

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
@@ -15,6 +15,7 @@
  */
 package com.github.benmanes.caffeine.cache;
 
+import static com.github.benmanes.caffeine.cache.Caffeine.calculateHashMapCapacity;
 import static java.util.Objects.requireNonNull;
 
 import java.io.Serializable;
@@ -476,7 +477,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
 
     @Override
     public Map<K, V> getAllPresent(Iterable<?> keys) {
-      Set<Object> uniqueKeys = new LinkedHashSet<>();
+      Set<Object> uniqueKeys = new LinkedHashSet<>(calculateHashMapCapacity(keys));
       for (Object key : keys) {
         uniqueKeys.add(key);
       }
@@ -1061,7 +1062,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
 
           @Override
           public void remove() {
-            Caffeine.requireState(removalKey != null);
+            requireState(removalKey != null);
             delegate.remove(removalKey);
             removalKey = null;
           }


### PR DESCRIPTION
I noticed that under intensive load, there is a performance penalty from the constant resizing LinkedHashSet in getAllPresent(). Since this was addressed in the master branch, I saw fit to use the same code from there and bring this improvement to v2.