### PR TITLE
Update Gradle example to be Groovy & Kotlin compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ Powering infrastructure near you:
 Download from [Maven Central][maven] or depend via Gradle:
 
 ```gradle
-implementation 'com.github.ben-manes.caffeine:caffeine:3.1.1'
+implementation("com.github.ben-manes.caffeine:caffeine:3.1.1")
 
 // Optional extensions
-implementation 'com.github.ben-manes.caffeine:guava:3.1.1'
-implementation 'com.github.ben-manes.caffeine:jcache:3.1.1'
+implementation("com.github.ben-manes.caffeine:guava:3.1.1")
+implementation("com.github.ben-manes.caffeine:jcache:3.1.1")
 ```
 
 For Java 11 or above, use `3.x` otherwise use `2.x`.


### PR DESCRIPTION
Kotlin-based Gradle files are quite popular now, providing an example that works for both `Groovy` (.gradle) *and* `Kotlin` (`.gradle.kts`) may slightly simplify trying out the library.