### PR TITLE
Filter invalid event in object store trace

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/keyvalue/ObjectStoreTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/keyvalue/ObjectStoreTraceReader.java
@@ -48,7 +48,7 @@ public final class ObjectStoreTraceReader extends TextTraceReader {
     return lines()
         .map(line -> line.split(" "))
         .filter(array -> array[1].equals("REST.GET.OBJECT"))
-        .map(array -> {
+        .flatMap(array -> {
           long key = new BigInteger(array[2], 16).longValue();
           int weight;
           if (array.length == 3) {
@@ -58,7 +58,10 @@ public final class ObjectStoreTraceReader extends TextTraceReader {
             long end = Long.parseLong(array[5]);
             weight = Ints.saturatedCast(end - start);
           }
-          return AccessEvent.forKeyAndWeight(key, weight);
+          if (weight < 0) {
+              return Stream.empty();
+          }
+          return Stream.of(AccessEvent.forKeyAndWeight(key, weight));
         });
   }
 }


### PR DESCRIPTION
The object store trace contains some range reads events with invalid ending offset leading to events with negative weight.
For example, the following events in `IBMObjectStoreTrace001Part0`:
```
192199064 REST.GET.OBJECT 6c44b4d75e985008 0 0 -1
192199064 REST.GET.OBJECT fb7caa17fb475a5c 0 0 -1
192200755 REST.GET.OBJECT 12c21c4f26736f15 0 0 -1
192200755 REST.GET.OBJECT a8a514e89f0ff7aa 0 0 -1
```

This PR filters these events as part of the reader to avoid pre-processing the input file