### PR TITLE
fix minor issue with array length condition in object storage traces

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/keyvalue/ObjectStoreTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/keyvalue/ObjectStoreTraceReader.java
@@ -50,14 +50,9 @@ public final class ObjectStoreTraceReader extends TextTraceReader {
         .filter(array -> array[1].equals("REST.GET.OBJECT"))
         .flatMap(array -> {
           long key = new BigInteger(array[2], 16).longValue();
-          int weight;
-          if (array.length == 3) {
-            weight = Integer.parseInt(array[3]);
-          } else {
-            long start = Long.parseLong(array[4]);
-            long end = Long.parseLong(array[5]);
-            weight = Ints.saturatedCast(end - start);
-          }
+          long start = Long.parseLong(array[4]);
+          long end = Long.parseLong(array[5]);
+          int  weight = Ints.saturatedCast(end - start);
           if (weight < 0) {
               return Stream.empty();
           }


### PR DESCRIPTION
This PR fixes a minor issue with the condition checking for GET requests without range reads.

In addition, since the reader filters only GET requests, I am not sure that the condition is needed at all, I haven't seen any GET request in the traces without range reads so it seems that this condition was never met anyway.
Maybe @ohadeytan knows if there are such cases.