### PR TITLE
JCache Cache.putAll(...) with immutable map can cause exception

### DIFF
--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/integration/CacheWriterTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/integration/CacheWriterTest.java
@@ -25,6 +25,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import javax.cache.integration.CacheWriter;
 import javax.cache.integration.CacheWriterException;
@@ -69,6 +70,19 @@ public final class CacheWriterTest extends AbstractJCacheTest {
       Assert.fail();
     } catch (CacheWriterException e) {
       assertThat(map).isEmpty();
+    }
+  }
+
+  @Test
+  public void putAllImmutable_fails() {
+    doThrow(CacheWriterException.class).when(writer).writeAll(any());
+    var immutableMap = Map.of(KEY_1, VALUE_1);
+
+    try {
+      jcache.putAll(immutableMap);
+      Assert.fail();
+    } catch (CacheWriterException e) {
+      assertThat(immutableMap).isEmpty();
     }
   }
 


### PR DESCRIPTION
Added test case showing that calling javax.cache.Cache.putAll(Map) with an immutable map causes a UnsupportedOperationException "if" the CacheWriter throws an exception. The problem with this is that you loose the original exception from the CacheWriter and thus do not know what the root cause was.

The issue appears to be with [CacheProxy](https://github.com/ben-manes/caffeine/blob/master/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java#L1063-L1072) in that it tries to remove entries from the original map. Which in this case is immutable.

Seems like similar issue in [CacheProxy.deleteAllToCacheWriter](https://github.com/ben-manes/caffeine/blob/master/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java#L1087-L1091)

I can change my code to be a mutable map but wanted to see what your thoughts were on this issue.