### PR TITLE
Add support for virtual threads: replace synchronized with ReentrantLock

### DIFF
--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/impl/LinkedHashMapCache.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/impl/LinkedHashMapCache.java
@@ -17,6 +17,7 @@ package com.github.benmanes.caffeine.cache.impl;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.github.benmanes.caffeine.cache.BasicCache;
 
@@ -25,6 +26,7 @@ import com.github.benmanes.caffeine.cache.BasicCache;
  */
 public final class LinkedHashMapCache<K, V> implements BasicCache<K, V> {
   private final Map<K, V> map;
+  private final ReentrantLock mapLock = new ReentrantLock();
 
   public LinkedHashMapCache(int maximumSize, boolean accessOrder) {
     map = new BoundedLinkedHashMap<>(maximumSize, accessOrder);
@@ -32,29 +34,41 @@ public final class LinkedHashMapCache<K, V> implements BasicCache<K, V> {
 
   @Override
   public V get(K key) {
-    synchronized (map) {
+    mapLock.lock();
+    try {
       return map.get(key);
+    } finally {
+      mapLock.unlock();
     }
   }
 
   @Override
   public void put(K key, V value) {
-    synchronized (map) {
+    mapLock.lock();
+    try {
       map.put(key, value);
+    } finally {
+      mapLock.unlock();
     }
   }
 
   @Override
   public void remove(K key) {
-    synchronized (map) {
+    mapLock.lock();
+    try {
       map.remove(key);
+    } finally {
+      mapLock.unlock();
     }
   }
 
   @Override
   public void clear() {
-    synchronized (map) {
+    mapLock.lock();
+    try {
       map.clear();
+    } finally {
+      mapLock.unlock();
     }
   }
 

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Node.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Node.java
@@ -18,6 +18,7 @@ package com.github.benmanes.caffeine.cache;
 import static java.util.Locale.US;
 
 import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -33,6 +34,12 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
  * @author ben.manes@gmail.com (Ben Manes)
  */
 abstract class Node<K, V> implements AccessOrder<Node<K, V>>, WriteOrder<Node<K, V>> {
+
+  private final ReentrantLock lock = new ReentrantLock();
+
+  final ReentrantLock getLock() {
+    return lock;
+  }
 
   /** Return the key or {@code null} if it has been reclaimed by the garbage collector. */
   @Nullable
@@ -55,7 +62,7 @@ abstract class Node<K, V> implements AccessOrder<Node<K, V>>, WriteOrder<Node<K,
   public abstract Object getValueReference();
 
   /** Sets the value, which may be held strongly, weakly, or softly. */
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public abstract void setValue(V value, @Nullable ReferenceQueue<V> referenceQueue);
 
   /**
@@ -66,13 +73,13 @@ abstract class Node<K, V> implements AccessOrder<Node<K, V>>, WriteOrder<Node<K,
 
   /** Returns the weight of this entry from the entry's perspective. */
   @NonNegative
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public int getWeight() {
     return 1;
   }
 
   /** Sets the weight from the entry's perspective. */
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public void setWeight(@NonNegative int weight) {}
 
   /** Returns the weight of this entry from the policy's perspective. */
@@ -95,19 +102,19 @@ abstract class Node<K, V> implements AccessOrder<Node<K, V>>, WriteOrder<Node<K,
    * If the entry was removed from the hash-table and is awaiting removal from the page
    * replacement policy.
    */
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public abstract boolean isRetired();
 
   /** If the entry was removed from the hash-table and the page replacement policy. */
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public abstract boolean isDead();
 
   /** Sets the node to the <tt>retired</tt> state. */
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public abstract void retire();
 
   /** Sets the node to the <tt>dead</tt> state. */
-  @GuardedBy("this")
+  @GuardedBy("getLock()")
   public abstract void die();
 
   /* --------------- Variable order --------------- */


### PR DESCRIPTION
Add support for virtual threads which was added to JDK 19: replace synchronized with ReentrantLock.

The use of ReentrantLock avoids that the carrier thread gets pinned.

See https://openjdk.org/jeps/425:
`The scheduler does not compensate for pinning by expanding its parallelism. Instead, avoid frequent and long-lived pinning by revising synchronized blocks or methods that run frequently and guard potentially long I/O operations to use java.util.concurrent.locks.ReentrantLock instead`