### PR TITLE
Add `@CanIgnoreReturnValue` annotations

### DIFF
--- a/caffeine/build.gradle
+++ b/caffeine/build.gradle
@@ -122,7 +122,6 @@ tasks.named('compileJava').configure {
   dependsOn generateLocalCaches, generateNodes
   finalizedBy compileCodeGenJava
   options.errorprone.disable('CheckReturnValue')
-  options.errorprone.error('CanIgnoreReturnValueSuggester')
 }
 tasks.named('compileTestJava').configure {
   dependsOn jar, compileCodeGenJava

--- a/caffeine/build.gradle
+++ b/caffeine/build.gradle
@@ -122,6 +122,7 @@ tasks.named('compileJava').configure {
   dependsOn generateLocalCaches, generateNodes
   finalizedBy compileCodeGenJava
   options.errorprone.disable('CheckReturnValue')
+  options.errorprone.error('CanIgnoreReturnValueSuggester')
 }
 tasks.named('compileTestJava').configure {
   dependsOn jar, compileCodeGenJava

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/local/package-info.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/local/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.local;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/package-info.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/node/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.node;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/package-info.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/impl/ConcurrentHashMapV7.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/impl/ConcurrentHashMapV7.java
@@ -113,8 +113,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * @param <K> the type of keys maintained by this map
  * @param <V> the type of mapped values
  */
-@SuppressWarnings({"all", "deprecation", "JdkObsolete", "rawtypes", "serial", "unchecked",
-  "UnnecessaryParentheses", "UnusedNestedClass", "UnusedVariable", "YodaCondition"})
+@SuppressWarnings({"all", "deprecation", "CheckReturnValue", "JdkObsolete", "rawtypes", "serial",
+  "unchecked", "UnnecessaryParentheses", "UnusedNestedClass", "UnusedVariable", "YodaCondition"})
 public class ConcurrentHashMapV7<K, V> extends AbstractMap<K, V>
         implements ConcurrentMap<K, V>, Serializable {
     private static final long serialVersionUID = 7249069246763182397L;

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/impl/package-info.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/impl/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.impl;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/package-info.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/sketch/package-info.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/cache/sketch/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.sketch;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/package-info.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/profiler/ProfilerHook.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/profiler/ProfilerHook.java
@@ -39,6 +39,7 @@ public abstract class ProfilerHook {
     calls = new LongAdder();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   public final void run() {
     scheduleStatusTask();
     ConcurrentTestHarness.timeTasks(NUM_THREADS, this::profile);

--- a/caffeine/src/jmh/java/com/github/benmanes/caffeine/profiler/package-info.java
+++ b/caffeine/src/jmh/java/com/github/benmanes/caffeine/profiler/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.profiler;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
@@ -471,6 +471,7 @@ public final class Caffeine<K, V> {
    *         remaining configuration and cache building
    * @throws IllegalStateException if a weigher was already set
    */
+  @CanIgnoreReturnValue
   public <K1 extends K, V1 extends V> Caffeine<K1, V1> weigher(
       Weigher<? super K1, ? super V1> weigher) {
     requireNonNull(weigher);
@@ -746,6 +747,7 @@ public final class Caffeine<K, V> {
    * @return this {@code Caffeine} instance (for chaining)
    * @throws IllegalStateException if expiration was already set
    */
+  @CanIgnoreReturnValue
   public <K1 extends K, V1 extends V> Caffeine<K1, V1> expireAfter(
       Expiry<? super K1, ? super V1> expiry) {
     requireNonNull(expiry);
@@ -899,6 +901,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalStateException if a removal listener was already set
    * @throws NullPointerException if the specified removal listener is null
    */
+  @CanIgnoreReturnValue
   public <K1 extends K, V1 extends V> Caffeine<K1, V1> evictionListener(
       RemovalListener<? super K1, ? super V1> evictionListener) {
     requireState(this.evictionListener == null,
@@ -950,6 +953,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalStateException if a removal listener was already set
    * @throws NullPointerException if the specified removal listener is null
    */
+  @CanIgnoreReturnValue
   public <K1 extends K, V1 extends V> Caffeine<K1, V1> removalListener(
       RemovalListener<? super K1, ? super V1> removalListener) {
     requireState(this.removalListener == null,

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java
@@ -46,6 +46,7 @@ import com.github.benmanes.caffeine.cache.Async.AsyncWeigher;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.stats.ConcurrentStatsCounter;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.FormatMethod;
 
 /**
@@ -291,6 +292,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalArgumentException if {@code initialCapacity} is negative
    * @throws IllegalStateException if an initial capacity was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> initialCapacity(@NonNegative int initialCapacity) {
     requireState(this.initialCapacity == UNSET_INT,
         "initial capacity was already set to %s", this.initialCapacity);
@@ -324,6 +326,7 @@ public final class Caffeine<K, V> {
    * @return this {@code Caffeine} instance (for chaining)
    * @throws NullPointerException if the specified executor is null
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> executor(Executor executor) {
     requireState(this.executor == null, "executor was already set to %s", this.executor);
     this.executor = requireNonNull(executor);
@@ -355,6 +358,7 @@ public final class Caffeine<K, V> {
    * @return this {@code Caffeine} instance (for chaining)
    * @throws NullPointerException if the specified scheduler is null
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> scheduler(Scheduler scheduler) {
     requireState(this.scheduler == null, "scheduler was already set to %s", this.scheduler);
     this.scheduler = requireNonNull(scheduler);
@@ -389,6 +393,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalArgumentException if {@code size} is negative
    * @throws IllegalStateException if a maximum size or weight was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> maximumSize(@NonNegative long maximumSize) {
     requireState(this.maximumSize == UNSET_INT,
         "maximum size was already set to %s", this.maximumSize);
@@ -425,6 +430,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalArgumentException if {@code maximumWeight} is negative
    * @throws IllegalStateException if a maximum weight or size was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> maximumWeight(@NonNegative long maximumWeight) {
     requireState(this.maximumWeight == UNSET_INT,
         "maximum weight was already set to %s", this.maximumWeight);
@@ -517,6 +523,7 @@ public final class Caffeine<K, V> {
    * @return this {@code Caffeine} instance (for chaining)
    * @throws IllegalStateException if the key strength was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> weakKeys() {
     requireState(keyStrength == null, "Key strength was already set to %s", keyStrength);
     keyStrength = Strength.WEAK;
@@ -546,6 +553,7 @@ public final class Caffeine<K, V> {
    * @return this {@code Caffeine} instance (for chaining)
    * @throws IllegalStateException if the value strength was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> weakValues() {
     requireState(valueStrength == null, "Value strength was already set to %s", valueStrength);
     valueStrength = Strength.WEAK;
@@ -582,6 +590,7 @@ public final class Caffeine<K, V> {
    * @return this {@code Caffeine} instance (for chaining)
    * @throws IllegalStateException if the value strength was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> softValues() {
     requireState(valueStrength == null, "Value strength was already set to %s", valueStrength);
     valueStrength = Strength.SOFT;
@@ -604,6 +613,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalStateException if the time to live or variable expiration was already set
    * @throws ArithmeticException for durations greater than +/- approximately 292 years
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> expireAfterWrite(Duration duration) {
     return expireAfterWrite(saturatedToNanos(duration), TimeUnit.NANOSECONDS);
   }
@@ -627,6 +637,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalArgumentException if {@code duration} is negative
    * @throws IllegalStateException if the time to live or variable expiration was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> expireAfterWrite(@NonNegative long duration, TimeUnit unit) {
     requireState(expireAfterWriteNanos == UNSET_INT,
         "expireAfterWrite was already set to %s ns", expireAfterWriteNanos);
@@ -663,6 +674,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalStateException if the time to idle or variable expiration was already set
    * @throws ArithmeticException for durations greater than +/- approximately 292 years
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> expireAfterAccess(Duration duration) {
     return expireAfterAccess(saturatedToNanos(duration), TimeUnit.NANOSECONDS);
   }
@@ -689,6 +701,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalArgumentException if {@code duration} is negative
    * @throws IllegalStateException if the time to idle or variable expiration was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> expireAfterAccess(@NonNegative long duration, TimeUnit unit) {
     requireState(expireAfterAccessNanos == UNSET_INT,
         "expireAfterAccess was already set to %s ns", expireAfterAccessNanos);
@@ -779,6 +792,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalStateException if the refresh interval was already set
    * @throws ArithmeticException for durations greater than +/- approximately 292 years
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> refreshAfterWrite(Duration duration) {
     return refreshAfterWrite(saturatedToNanos(duration), TimeUnit.NANOSECONDS);
   }
@@ -806,6 +820,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalArgumentException if {@code duration} is zero or negative
    * @throws IllegalStateException if the refresh interval was already set
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> refreshAfterWrite(@NonNegative long duration, TimeUnit unit) {
     requireNonNull(unit);
     requireState(refreshAfterWriteNanos == UNSET_INT,
@@ -835,6 +850,7 @@ public final class Caffeine<K, V> {
    * @throws IllegalStateException if a ticker was already set
    * @throws NullPointerException if the specified ticker is null
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> ticker(Ticker ticker) {
     requireState(this.ticker == null, "Ticker was already set to %s", this.ticker);
     this.ticker = requireNonNull(ticker);
@@ -961,6 +977,7 @@ public final class Caffeine<K, V> {
    *
    * @return this {@code Caffeine} instance (for chaining)
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> recordStats() {
     requireState(this.statsCounterSupplier == null, "Statistics recording was already set");
     statsCounterSupplier = ENABLED_STATS_COUNTER_SUPPLIER;
@@ -977,6 +994,7 @@ public final class Caffeine<K, V> {
    * @param statsCounterSupplier a supplier instance that returns a new {@link StatsCounter}
    * @return this {@code Caffeine} instance (for chaining)
    */
+  @CanIgnoreReturnValue
   public Caffeine<K, V> recordStats(Supplier<? extends StatsCounter> statsCounterSupplier) {
     requireState(this.statsCounterSupplier == null, "Statistics recording was already set");
     requireNonNull(statsCounterSupplier);

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Weigher.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Weigher.java
@@ -53,8 +53,8 @@ public interface Weigher<K, V> {
    */
   static <K, V> Weigher<K, V> singletonWeigher() {
     @SuppressWarnings("unchecked")
-    Weigher<K, V> self = (Weigher<K, V>) SingletonWeigher.INSTANCE;
-    return self;
+    Weigher<K, V> instance = (Weigher<K, V>) SingletonWeigher.INSTANCE;
+    return instance;
   }
 
   /**

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/apache/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/apache/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.apache;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/CaffeineSpecGuavaTest.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/CaffeineSpecGuavaTest.java
@@ -32,7 +32,7 @@ import junit.framework.TestCase;
  *
  * @author Adam Winer
  */
-@SuppressWarnings({"CheckReturnValue", "PreferJavaTimeOverload"})
+@SuppressWarnings("PreferJavaTimeOverload")
 public class CaffeineSpecGuavaTest extends TestCase {
 
   public void testParse_empty() {

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/buffer/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/buffer/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.buffer;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/issues/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/issues/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.issues;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/stats/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/stats/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.stats;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/testing/CacheContextSubject.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/testing/CacheContextSubject.java
@@ -55,6 +55,7 @@ import com.google.common.collect.ImmutableMultiset;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.StandardSubjectBuilder;
 import com.google.common.truth.Subject;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * Propositions for {@link CacheContext} subjects.
@@ -219,30 +220,37 @@ public final class CacheContextSubject extends Subject {
           || (context.executorType() == CacheExecutor.DIRECT);
     }
 
+    @CanIgnoreReturnValue
     public StatsSubject hits(long count) {
       return awaitStatistic("hitCount", CacheStats::hitCount, count);
     }
 
+    @CanIgnoreReturnValue
     public StatsSubject misses(long count) {
       return awaitStatistic("missCount", CacheStats::missCount, count);
     }
 
+    @CanIgnoreReturnValue
     public StatsSubject evictions(long count) {
       return awaitStatistic("evictionCount", CacheStats::evictionCount, count);
     }
 
+    @CanIgnoreReturnValue
     public StatsSubject evictionWeight(long count) {
       return awaitStatistic("evictionWeight", CacheStats::evictionWeight, count);
     }
 
+    @CanIgnoreReturnValue
     public StatsSubject success(long count) {
       return awaitStatistic("loadSuccessCount", CacheStats::loadSuccessCount, count);
     }
 
+    @CanIgnoreReturnValue
     public StatsSubject failures(long count) {
       return awaitStatistic("loadFailureCount", CacheStats::loadFailureCount, count);
     }
 
+    @CanIgnoreReturnValue
     private StatsSubject awaitStatistic(String label,
         ToLongFunction<CacheStats> supplier, long expectedValue) {
       if (isDirect) {

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/testing/ExpiryBuilder.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/testing/ExpiryBuilder.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.Serializable;
 
 import com.github.benmanes.caffeine.cache.Expiry;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * A builder for unit test convenience.
@@ -45,12 +46,14 @@ public final class ExpiryBuilder {
   }
 
   /** Sets the fixed update expiration time. */
+  @CanIgnoreReturnValue
   public ExpiryBuilder expiringAfterUpdate(long nanos) {
     updateNanos = nanos;
     return this;
   }
 
   /** Sets the fixed read expiration time. */
+  @CanIgnoreReturnValue
   public ExpiryBuilder expiringAfterRead(long nanos) {
     readNanos = nanos;
     return this;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/testing/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/testing/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.testing;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/eclipse/acceptance/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/eclipse/acceptance/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.eclipse.acceptance;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/eclipse/mutable/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/eclipse/mutable/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.eclipse.mutable;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/eclipse/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/eclipse/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.eclipse;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/google/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/google/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.google;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/jsr166/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/jsr166/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jsr166;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/lincheck/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/lincheck/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.lincheck;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/testing/package-info.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/testing/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.testing;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/examples/coalescing-bulkloader/src/main/java/com/github/benmanes/caffeine/examples/coalescing/bulkloader/package-info.java
+++ b/examples/coalescing-bulkloader/src/main/java/com/github/benmanes/caffeine/examples/coalescing/bulkloader/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.examples.coalescing.bulkloader;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/examples/coalescing-bulkloader/src/test/java/com/github/benmanes/caffeine/examples/coalescing/bulkloader/package-info.java
+++ b/examples/coalescing-bulkloader/src/test/java/com/github/benmanes/caffeine/examples/coalescing/bulkloader/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.examples.coalescing.bulkloader;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/examples/write-behind-rxjava/src/main/java/com/github/benmanes/caffeine/examples/writebehind/rxjava/WriteBehindCacheWriter.java
+++ b/examples/write-behind-rxjava/src/main/java/com/github/benmanes/caffeine/examples/writebehind/rxjava/WriteBehindCacheWriter.java
@@ -27,6 +27,8 @@ import java.util.function.Consumer;
 
 import io.reactivex.subjects.PublishSubject;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 /**
  * This class allows a cache to have "write-behind" semantics. The passed in writeAction will only
  * be called every 'bufferTime' time with a Map containing the keys and the values that have been
@@ -67,18 +69,21 @@ public final class WriteBehindCacheWriter<K, V> {
      * The duration that the calls to the cache should be buffered before calling the
      * <code>writeAction</code>.
      */
+    @CanIgnoreReturnValue
     public Builder<K, V> bufferTime(long duration, TimeUnit unit) {
       this.bufferTimeNanos = TimeUnit.NANOSECONDS.convert(duration, unit);
       return this;
     }
 
     /** The callback to perform the writing to the database or repository. */
+    @CanIgnoreReturnValue
     public Builder<K, V> writeAction(Consumer<Map<K, V>> writeAction) {
       this.writeAction = requireNonNull(writeAction);
       return this;
     }
 
     /** The action that decides which value to take in case a key was updated multiple times. */
+    @CanIgnoreReturnValue
     public Builder<K, V> coalesce(BinaryOperator<V> coalescer) {
       this.coalescer = requireNonNull(coalescer);
       return this;

--- a/examples/write-behind-rxjava/src/main/java/com/github/benmanes/caffeine/examples/writebehind/rxjava/package-info.java
+++ b/examples/write-behind-rxjava/src/main/java/com/github/benmanes/caffeine/examples/writebehind/rxjava/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package src.main.java.com.github.benmanes.caffeine.examples.writebehind.rxjava;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/examples/write-behind-rxjava/src/test/java/com/github/benmanes/caffeine/examples/writebehind/rxjava/package-info.java
+++ b/examples/write-behind-rxjava/src/test/java/com/github/benmanes/caffeine/examples/writebehind/rxjava/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package src.test.java.com.github.benmanes.caffeine.examples.writebehind.rxjava;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/gradle/codeQuality.gradle
+++ b/gradle/codeQuality.gradle
@@ -170,7 +170,7 @@ tasks.withType(JavaCompile).configureEach {
       'LexicographicalAnnotationListing', 'MissingSummary', 'StaticImport' ]
     disabledChecks.each { disable(it) }
 
-    def errorChecks = [ 'NullAway' ]
+    def errorChecks = [ 'CanIgnoreReturnValueSuggester', 'NullAway' ]
     errorChecks.each { error(it) }
 
     nullaway {

--- a/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaCache.java
+++ b/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaCache.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ForwardingSet;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * A Caffeine-backed cache through a Guava facade.
@@ -240,6 +241,7 @@ class CaffeinatedGuavaCache<K, V> implements Cache<K, V>, Serializable {
     CacheLoaderException(Exception e) {
       super(e);
     }
+    @CanIgnoreReturnValue
     @SuppressWarnings({"lgtm [java/non-sync-override]", "UnsynchronizedOverridesSynchronized"})
     @Override public Throwable fillInStackTrace() {
       return this;

--- a/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaLoadingCache.java
+++ b/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaLoadingCache.java
@@ -123,7 +123,7 @@ final class CaffeinatedGuavaLoadingCache<K, V>
   }
 
   @Override
-  @SuppressWarnings({"CheckReturnValue", "FutureReturnValueIgnored"})
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void refresh(K key) {
     cache.refresh(key);
   }

--- a/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/CacheBuilderFactory.java
+++ b/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/CacheBuilderFactory.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * Helper class for creating {@link CacheBuilder} instances with all combinations of several sets of
@@ -36,7 +37,6 @@ import com.google.common.util.concurrent.MoreExecutors;
  *
  * @author mike nonemacher
  */
-@SuppressWarnings({"CanIgnoreReturnValueSuggester", "CheckReturnValue"})
 class CacheBuilderFactory {
   // Default values contain only 'null', which means don't call the CacheBuilder method (just give
   // the CacheBuilder default).
@@ -49,42 +49,50 @@ class CacheBuilderFactory {
   private Set<Strength> keyStrengths = Sets.newHashSet((Strength) null);
   private Set<Strength> valueStrengths = Sets.newHashSet((Strength) null);
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withConcurrencyLevels(Set<Integer> concurrencyLevels) {
     this.concurrencyLevels = Sets.newLinkedHashSet(concurrencyLevels);
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withInitialCapacities(Set<Integer> initialCapacities) {
     this.initialCapacities = Sets.newLinkedHashSet(initialCapacities);
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withMaximumSizes(Set<Integer> maximumSizes) {
     this.maximumSizes = Sets.newLinkedHashSet(maximumSizes);
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withExpireAfterWrites(Set<DurationSpec> durations) {
     this.expireAfterWrites = Sets.newLinkedHashSet(durations);
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withExpireAfterAccesses(Set<DurationSpec> durations) {
     this.expireAfterAccesses = Sets.newLinkedHashSet(durations);
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withRefreshes(Set<DurationSpec> durations) {
     this.refreshes = Sets.newLinkedHashSet(durations);
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withKeyStrengths(Set<Strength> keyStrengths) {
     this.keyStrengths = Sets.newLinkedHashSet(keyStrengths);
     Preconditions.checkArgument(!this.keyStrengths.contains(Strength.SOFT));
     return this;
   }
 
+  @CanIgnoreReturnValue
   CacheBuilderFactory withValueStrengths(Set<Strength> valueStrengths) {
     this.valueStrengths = Sets.newLinkedHashSet(valueStrengths);
     return this;

--- a/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/CacheBuilderTest.java
+++ b/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/CacheBuilderTest.java
@@ -61,7 +61,7 @@ import junit.framework.TestCase;
  */
 @GwtCompatible(emulated = true)
 @SuppressWarnings({"CacheLoaderNull", "CanonicalDuration",
-  "CheckReturnValue", "PreferJavaTimeOverload", "ThreadPriorityCheck"})
+  "PreferJavaTimeOverload", "ThreadPriorityCheck"})
 public class CacheBuilderTest extends TestCase {
 
   public void testNewBuilder() {

--- a/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/LocalLoadingCacheTest.java
+++ b/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/LocalLoadingCacheTest.java
@@ -55,6 +55,7 @@ public class LocalLoadingCacheTest extends TestCase {
 
   // constructor tests
 
+  @SuppressWarnings("CheckReturnValue")
   public void testComputingFunction() {
     CacheLoader<Object, Object> loader = new CacheLoader<Object, Object>() {
       @Override

--- a/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/package-info.java
+++ b/guava/src/test/java/com/github/benmanes/caffeine/guava/compatibility/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.guava.compatibility;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/guava/src/test/java/com/github/benmanes/caffeine/guava/package-info.java
+++ b/guava/src/test/java/com/github/benmanes/caffeine/guava/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.guava;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheFactory.java
@@ -126,7 +126,6 @@ final class CacheFactory {
   }
 
   /** A one-shot builder for creating a cache instance. */
-  @SuppressWarnings("CheckReturnValue")
   private static final class Builder<K, V> {
     final Ticker ticker;
     final String cacheName;

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -73,6 +73,7 @@ import com.github.benmanes.caffeine.jcache.management.JCacheStatisticsMXBean;
 import com.github.benmanes.caffeine.jcache.management.JmxRegistration;
 import com.github.benmanes.caffeine.jcache.management.JmxRegistration.MBeanType;
 import com.github.benmanes.caffeine.jcache.processor.EntryProcessorEntry;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * An implementation of JSR-107 {@link Cache} backed by a Caffeine cache.
@@ -279,7 +280,6 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   /** Performs the bulk load where the existing entries are replaced. */
-  @SuppressWarnings("CheckReturnValue")
   private void loadAllAndReplaceExisting(Set<? extends K> keys) {
     Map<K, V> loaded = cacheLoader.orElseThrow().loadAll(keys);
     for (var entry : loaded.entrySet()) {
@@ -288,7 +288,6 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   /** Performs the bulk load where the existing entries are retained. */
-  @SuppressWarnings("CheckReturnValue")
   private void loadAllAndKeepExisting(Set<? extends K> keys) {
     List<K> keysToLoad = keys.stream()
         .filter(key -> !cache.asMap().containsKey(key))
@@ -351,6 +350,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
    * @param publishToWriter if the writer should be notified
    * @return the old value
    */
+  @CanIgnoreReturnValue
   protected PutResult<V> putNoCopyOrAwait(K key, V value, boolean publishToWriter) {
     requireNonNull(key);
     requireNonNull(value);
@@ -474,6 +474,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
    * @param publishToWriter if the writer should be notified
    * @return if the mapping was successful
    */
+  @CanIgnoreReturnValue
   private boolean putIfAbsentNoAwait(K key, V value, boolean publishToWriter) {
     boolean[] absent = { false };
     cache.asMap().compute(copyOf(key), (k, expirable) -> {
@@ -552,6 +553,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   @Override
+  @CanIgnoreReturnValue
   public boolean remove(K key, V oldValue) {
     requireNotClosed();
     requireNonNull(key);
@@ -1238,7 +1240,6 @@ public class CacheProxy<K, V> implements Cache<K, V> {
     }
 
     @Override
-    @SuppressWarnings("CheckReturnValue")
     public void remove() {
       if (current == null) {
         throw new IllegalStateException();

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -444,6 +444,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   @Override
+  @CanIgnoreReturnValue
   public boolean putIfAbsent(K key, V value) {
     requireNotClosed();
     requireNonNull(value);
@@ -508,6 +509,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   @Override
+  @CanIgnoreReturnValue
   public boolean remove(K key) {
     requireNotClosed();
     requireNonNull(key);
@@ -621,6 +623,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   @Override
+  @CanIgnoreReturnValue
   public boolean replace(K key, V oldValue, V newValue) {
     requireNotClosed();
     requireNonNull(oldValue);
@@ -673,6 +676,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
   }
 
   @Override
+  @CanIgnoreReturnValue
   public boolean replace(K key, V value) {
     requireNotClosed();
     boolean statsEnabled = statistics.isEnabled();

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurationTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurationTest.java
@@ -72,7 +72,6 @@ public final class TypesafeConfigurationTest {
     assertThat(TypesafeConfigurator.from(ConfigFactory.load(), "#")).isEmpty();
   }
 
-  @SuppressWarnings("CheckReturnValue")
   @Test(expectedExceptions = IllegalStateException.class)
   public void invalidCache() {
     TypesafeConfigurator.from(ConfigFactory.load(), "invalid-cache");

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/configuration/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.configuration;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/copy/JavaSerializationCopierTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/copy/JavaSerializationCopierTest.java
@@ -44,7 +44,6 @@ import com.google.common.collect.ImmutableSet;
 /**
  * @author ben.manes@gmail.com (Ben Manes)
  */
-@SuppressWarnings("CheckReturnValue")
 public final class JavaSerializationCopierTest {
 
   @Test(dataProvider = "nullArgs", expectedExceptions = NullPointerException.class)

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/copy/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/copy/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.copy;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/event/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/event/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.event;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/expiry/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/expiry/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.expiry;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/integration/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/integration/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.integration;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/management/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/management/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.management;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/processor/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/processor/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.processor;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/size/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/size/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.size;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/spi/package-info.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/spi/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.jcache.spi;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/simulator/build.gradle
+++ b/simulator/build.gradle
@@ -65,7 +65,6 @@ tasks.named('sourcesJar').configure {
 
 tasks.withType(JavaCompile).configureEach {
   options.errorprone {
-    disable('CanIgnoreReturnValueSuggester')
     nullaway.disable()
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/admission/countmin4/CountMin4.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/admission/countmin4/CountMin4.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.admission.Frequency;
 import com.google.common.math.IntMath;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.typesafe.config.Config;
 
 /**
@@ -126,7 +127,6 @@ public abstract class CountMin4 implements Frequency {
   }
 
   /** Increments the associated counters that are at the observed minimum. */
-  @SuppressWarnings("CheckReturnValue")
   void conservativeIncrement(long e) {
     int hash = spread(Long.hashCode(e));
     int start = (hash & 3) << 2;
@@ -164,6 +164,7 @@ public abstract class CountMin4 implements Frequency {
    * @param step the increase amount
    * @return if incremented
    */
+  @CanIgnoreReturnValue
   boolean incrementAt(int i, int j, long step) {
     int offset = j << 2;
     long mask = (0xfL << offset);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/penalties/package-info.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/penalties/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.simulator.parser.address.penalties;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyStats.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/PolicyStats.java
@@ -36,6 +36,7 @@ import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * Statistics gathered by a policy execution. A policy can extend this class as a convenient way to
@@ -318,6 +319,7 @@ public class PolicyStats {
       public abstract ImmutableSet.Builder<Characteristic> characteristicsBuilder();
       public abstract Metric build();
 
+      @CanIgnoreReturnValue
       public final Builder addCharacteristic(Characteristic characteristic) {
         characteristicsBuilder().add(characteristic);
         return this;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimplePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimplePolicy.java
@@ -22,6 +22,7 @@ import com.github.benmanes.caffeine.cache.simulator.policy.Policy.KeyOnlyPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.PolicySpec;
 import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
 import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.typesafe.config.Config;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
@@ -197,7 +198,6 @@ public final class ClockProSimplePolicy implements KeyOnlyPolicy {
     evict();
   }
 
-  @SuppressWarnings("CheckReturnValue")
   private void evict() {
     policyStats.recordEviction();
     while (maxSize < sizeCold + sizeHot) {
@@ -272,6 +272,7 @@ public final class ClockProSimplePolicy implements KeyOnlyPolicy {
 
   // ScanHot demotes a hot entry between the oldest hot entry's epoch and the given epoch.
   // If the demotion was successful it returns true, otherwise it returns false.
+  @CanIgnoreReturnValue
   private boolean scanHot(long epoch) {
     for (Node victim = headHot.prev; victim.epoch <= epoch; victim = headHot.prev) {
       policyStats.recordOperation();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/product/CaffeinePolicy.java
@@ -40,7 +40,6 @@ public final class CaffeinePolicy implements Policy {
   private final Cache<Long, AccessEvent> cache;
   private final PolicyStats policyStats;
 
-  @SuppressWarnings("CheckReturnValue")
   public CaffeinePolicy(Config config, Set<Characteristic> characteristics) {
     policyStats = new PolicyStats(name());
     BasicSettings settings = new BasicSettings(config);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/gradient/package-info.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/gradient/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.gradient;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/hill/package-info.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/hill/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.hill;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/inference/package-info.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/inference/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.inference;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/sim/package-info.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/sim/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing.sim;
+
+import com.google.errorprone.annotations.CheckReturnValue;

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/admission/bloom/package-info.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/admission/bloom/package-info.java
@@ -1,0 +1,4 @@
+@CheckReturnValue
+package com.github.benmanes.caffeine.cache.simulator.admission.bloom;
+
+import com.google.errorprone.annotations.CheckReturnValue;


### PR DESCRIPTION
Suggested commit message:
```
Add `@CanIgnoreReturnValue` annotations

This cancels out the package-level `@CheckReturnValue` annotations
introduced in ff1238567ede4001270ac6ed4682989b6b508c7e for selected
methods.

While there, add `@CheckReturnValue` to all remaining packages.
```

Reason for filing this PR, is that when upgrading to Caffeine 3.1.3 our build fails with
```
[WARNING] /path/to/CacheFactory.java:[365,59] [CheckReturnValue] The result of `recordStats(...)` must be used
  If you really don't want to use the result, then assign it to a variable: `var unused = ...`.

  If callers of `recordStats(...)` shouldn't be required to use its result, then annotate it with `@CanIgnoreReturnValue`.

    (see https://errorprone.info/bugpattern/CheckReturnValue
 Did you mean 'statsCounter.ifPresent(counter -> caffeine = caffeine.recordStats(() -> counter));'?
```
The above error is triggered by this code:
```java
statsCounter.ifPresent(counter -> caffeine.recordStats(() -> counter));
```

(Our build has nearly all Error Prone checks enabled.)