### PR TITLE
#1347 - Fix for hibernate.javax.cache.uri in JakartaEE EARs

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
@@ -170,10 +170,6 @@ public final class TypesafeConfigurator {
       return ConfigFactory.defaultOverrides(classloader)
           .withFallback(ConfigFactory.parseFile(new File(uri), options))
           .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
-    } else if (isResource(uri)) {
-      return ConfigFactory.defaultOverrides(classloader)
-          .withFallback(ConfigFactory.parseResources(uri.getSchemeSpecificPart(), options))
-          .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
     } else if ((uri.getScheme() != null) && uri.getScheme().equalsIgnoreCase("jar")) {
         try (Reader reader = new InputStreamReader(uri.toURL().openStream())) {
           return ConfigFactory.defaultOverrides(classloader)
@@ -182,6 +178,10 @@ public final class TypesafeConfigurator {
         } catch (IOException e) {
           throw new ConfigException.BadPath(uri.toString(), e.getMessage());
         }
+    } else if (isResource(uri)) {
+      return ConfigFactory.defaultOverrides(classloader)
+          .withFallback(ConfigFactory.parseResources(uri.getSchemeSpecificPart(), options))
+          .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
     }
     return ConfigFactory.load(classloader);
   }

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
@@ -15,11 +15,15 @@
  */
 package com.github.benmanes.caffeine.jcache.configuration;
 
+
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.net.URI;
@@ -170,6 +174,14 @@ public final class TypesafeConfigurator {
       return ConfigFactory.defaultOverrides(classloader)
           .withFallback(ConfigFactory.parseResources(uri.getSchemeSpecificPart(), options))
           .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
+    } else if ((uri.getScheme() != null) && uri.getScheme().equalsIgnoreCase("jar")) {
+        try (Reader reader = new InputStreamReader(uri.toURL().openStream())) {
+          return ConfigFactory.defaultOverrides(classloader)
+              .withFallback(ConfigFactory.parseReader(reader, options))
+              .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
+        } catch (IOException e) {
+          throw new ConfigException.BadPath(uri.toString(), e.getMessage());
+        }
     }
     return ConfigFactory.load(classloader);
   }

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
@@ -174,7 +174,7 @@ public final class TypesafeConfigurator {
               .withFallback(ConfigFactory.parseURL(uri.toURL(), options))
               .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
         } catch (MalformedURLException e) {
-          throw new ConfigException.BadPath(uri.toString(), e.getMessage());
+          throw new ConfigException.BadPath(uri.toString(), "Failed to load cache configuration", e);
         }
     } else if (isResource(uri)) {
       return ConfigFactory.defaultOverrides(classloader)

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/configuration/TypesafeConfigurator.java
@@ -21,11 +21,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Objects;
@@ -171,11 +169,11 @@ public final class TypesafeConfigurator {
           .withFallback(ConfigFactory.parseFile(new File(uri), options))
           .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
     } else if ((uri.getScheme() != null) && uri.getScheme().equalsIgnoreCase("jar")) {
-        try (Reader reader = new InputStreamReader(uri.toURL().openStream())) {
+        try {
           return ConfigFactory.defaultOverrides(classloader)
-              .withFallback(ConfigFactory.parseReader(reader, options))
+              .withFallback(ConfigFactory.parseURL(uri.toURL(), options))
               .withFallback(ConfigFactory.defaultReferenceUnresolved(classloader));
-        } catch (IOException e) {
+        } catch (MalformedURLException e) {
           throw new ConfigException.BadPath(uri.toString(), e.getMessage());
         }
     } else if (isResource(uri)) {


### PR DESCRIPTION
As mentioned in [#1347](https://github.com/ben-manes/caffeine/issues/1347), the URIs in case of JakartaEE jar files are neither **file:** nor **classpath:** but **jar:**.
Extend the TypesafeConfigurator#resolveConfig to properly pass also jar: protocol URLs, so the Caffeine can be used as Hibernate's 2nd level cache in complex JakartaEE applications.