### PR TITLE
Set remote build cache to push only if authenticated

### DIFF
--- a/gradle/gradle-enterprise.gradle
+++ b/gradle/gradle-enterprise.gradle
@@ -25,12 +25,14 @@ buildCache {
   local.enabled = true
   remote(HttpBuildCache) {
     url = 'https://caffeine.gradle-enterprise.cloud/cache/'
-    push = System.env.CI
     enabled = true
+    def cachePassword = settings.ext.find('gradleEnterpriseCachePassword')
+        ?: System.env.GRADLE_ENTERPRISE_CACHE_PASSWORD
+    // Check cache password presence to avoid build cache errors on PR builds when not present
+    push = System.env.CI && cachePassword
     credentials {
       username = 'ci'
-      password = settings.ext.find('gradleEnterpriseCachePassword')
-        ?: System.env.GRADLE_ENTERPRISE_CACHE_PASSWORD
+      password = cachePassword
     }
   }
 }


### PR DESCRIPTION
Updated remote build cache config to only push when authenticated -> if an unauthenticated push is attempted remote build cache will get turned off for the rest of the build. This can happen (does) on forked PR builds which run in an unsecure environment.