### PR TITLE
When `AsyncCacheLoader.asyncLoadAll` returns excess keys, wait for all keys to be added to the cache before returning requested keys

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
@@ -144,8 +144,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
     try {
       var loader = mappingFunction.apply(
           Collections.unmodifiableSet(proxies.keySet()), cache().executor());
-      loader.whenComplete(completer);
-      return composeResult(futures);
+      return loader.whenComplete(completer).thenCompose(ignored -> composeResult(futures));
     } catch (Throwable t) {
       completer.accept(/* result */ null, t);
       throw t;

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/AsyncLoadingCacheTest.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/AsyncLoadingCacheTest.java
@@ -319,7 +319,8 @@ public final class AsyncLoadingCacheTest {
 
   @Test(dataProvider = "caches")
   @CacheSpec(loader = Loader.BULK_NEGATIVE_EXCEEDS,
-      removalListener = { Listener.DISABLED, Listener.REJECTING })
+      removalListener = { Listener.DISABLED, Listener.REJECTING },
+      executor = { CacheExecutor.DIRECT, CacheExecutor.DEFAULT })
   public void getAll_exceeds(AsyncLoadingCache<Int, Int> cache, CacheContext context) {
     var result = cache.getAll(context.absentKeys()).join();
 


### PR DESCRIPTION
Fixes #1409.

Verified by running the `getAll_exceeds` test with the `ForkJoinPool` executor. Running this test configuration before the change would fail sporadically due to a race between the excess entries being added to the cache and the cache size assertion.