### PR TITLE
Adding Bootique to the list of projects that work with Caffeine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use Caffeine in a community provided integration:
 * [Camel][camel]: Routing and mediation engine
 * [JHipster][jhipster]: Generate, develop, deploy
 * [Aedile][aedile]: Kotlin wrapper for Caffeine
-* [Bootique][bootique]: A minimally opinionated framework for runnable Java apps
+* [Bootique][bootique]: A fast, simple Java platform
 
 Powering infrastructure near you:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Use Caffeine in a community provided integration:
 * [Camel][camel]: Routing and mediation engine
 * [JHipster][jhipster]: Generate, develop, deploy
 * [Aedile][aedile]: Kotlin wrapper for Caffeine
+* [Bootique][bootique]: A minimally opinionated framework for runnable Java apps
 
 Powering infrastructure near you:
 
@@ -161,3 +162,4 @@ Snapshots of the development version are available in
 [grails]: https://grails.org
 [quarkus]: https://quarkus.io
 [aedile]: https://github.com/sksamuel/aedile
+[bootique]: https://bootique.io/


### PR DESCRIPTION
A specific Bootique/Caffeine example is provided here: https://github.com/bootique-examples/bootique-jcache-examples/tree/3.x/jcache-caffeine-example