### PR TITLE
Fix incorrect date format pattern in unit test

### DIFF
--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/issues/Issue30Test.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/issues/Issue30Test.java
@@ -151,7 +151,7 @@ public final class Issue30Test {
 
   static final class Loader implements AsyncCacheLoader<String, String> {
     private static final DateTimeFormatter FORMATTER =
-        DateTimeFormatter.ofPattern("hh:MM:ss.SSS", US);
+        DateTimeFormatter.ofPattern("HH:mm:ss.SSS", US);
 
     final ConcurrentMap<String, String> source;
     final ConcurrentMap<String, Instant> lastLoad;


### PR DESCRIPTION
Fixes #1788

Regarding the change `h` ('clock-hour-of-am-pm (1-12)') to `H` ('hour-of-day (0-23)'):
Maybe the usage of `h` was intended before, since it is also using the `US` locale, however then maybe it should have included the am/pm marker?