### PR TITLE
Remove some unneeded suppressions

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -3070,7 +3070,6 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
   }
 
   @Override
-  @SuppressWarnings("NullAway")
   public int hashCode() {
     @Var int hash = 0;
     long now = expirationTicker().read();

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/CaffeineSpec.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/CaffeineSpec.java
@@ -320,7 +320,6 @@ public final class CaffeineSpec {
 
   /** Returns a parsed duration using the simple time unit format. */
   static Duration parseSimpleDuration(String key, String value) {
-    @SuppressWarnings("NullAway")
     long duration = parseLong(key, value.substring(0, value.length() - 1));
     TimeUnit unit = parseTimeUnit(key, value);
     return Duration.ofNanos(unit.toNanos(duration));

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/UnboundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/UnboundedLocalCache.java
@@ -103,7 +103,6 @@ final class UnboundedLocalCache<K, V> implements LocalCache<K, V> {
   }
 
   @Override
-  @SuppressWarnings("NullAway")
   public @Nullable Expiry<K, V> expiry() {
     return null;
   }

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/AsyncCacheTest.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/AsyncCacheTest.java
@@ -427,7 +427,6 @@ public final class AsyncCacheTest {
     assertThat(result).isExhaustivelyEmpty();
   }
 
-  @SuppressWarnings("NullAway")
   @Test(dataProvider = "caches")
   @CacheSpec(removalListener = { Listener.DISABLED, Listener.REJECTING })
   public void getAllFunction_nullLookup(AsyncCache<Int, Int> cache, CacheContext context) {

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/testing/MapSubject.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/testing/MapSubject.java
@@ -44,7 +44,6 @@ public class MapSubject extends com.google.common.truth.MapSubject {
     this.actual = subject;
   }
 
-  @SuppressWarnings("NullAway")
   public static Factory<MapSubject, Map<?, ?>> map() {
     return MapSubject::new;
   }

--- a/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaCache.java
+++ b/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaCache.java
@@ -65,7 +65,7 @@ class CaffeinatedGuavaCache<K, V> implements Cache<K, V>, Serializable {
   }
 
   @Override
-  @SuppressWarnings({"NullAway", "PMD.ExceptionAsFlowControl", "PMD.PreserveStackTrace"})
+  @SuppressWarnings({"PMD.ExceptionAsFlowControl", "PMD.PreserveStackTrace"})
   public V get(K key, Callable<? extends V> valueLoader) throws ExecutionException {
     requireNonNull(valueLoader);
     try {

--- a/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaLoadingCache.java
+++ b/guava/src/main/java/com/github/benmanes/caffeine/guava/CaffeinatedGuavaLoadingCache.java
@@ -57,7 +57,7 @@ final class CaffeinatedGuavaLoadingCache<K, V>
   }
 
   @Override
-  @SuppressWarnings({"NullAway", "PMD.PreserveStackTrace"})
+  @SuppressWarnings("PMD.PreserveStackTrace")
   public V get(K key) throws ExecutionException {
     requireNonNull(key);
     try {
@@ -74,7 +74,7 @@ final class CaffeinatedGuavaLoadingCache<K, V>
   }
 
   @Override
-  @SuppressWarnings({"CatchingUnchecked", "NullAway",
+  @SuppressWarnings({"CatchingUnchecked",
     "PMD.AvoidCatchingNPE", "PMD.PreserveStackTrace"})
   public V getUnchecked(K key) {
     try {
@@ -117,7 +117,7 @@ final class CaffeinatedGuavaLoadingCache<K, V>
   }
 
   @Override
-  @SuppressWarnings({"deprecation", "NullAway"})
+  @SuppressWarnings("deprecation")
   public V apply(K key) {
     return cache.get(key);
   }

--- a/guava/src/test/java/com/github/benmanes/caffeine/guava/GuavaMapTests.java
+++ b/guava/src/test/java/com/github/benmanes/caffeine/guava/GuavaMapTests.java
@@ -40,7 +40,6 @@ public final class GuavaMapTests extends TestCase {
       return cache.asMap();
     })));
     suite.addTest(MapTestFactory.suite("GuavaLoadingView", generator(() -> {
-      @SuppressWarnings("NullAway")
       Cache<String, String> cache = CaffeinatedGuava.build(
           Caffeine.newBuilder().maximumSize(Long.MAX_VALUE),
           key -> { throw new AssertionError(); });

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -213,8 +213,6 @@ public class CacheProxy<K, V> implements Cache<K, V> {
    */
   protected Map<K, Expirable<V>> getAndFilterExpiredEntries(
       Set<? extends K> keys, boolean updateAccessTime) {
-    // NullAway does not yet understand the @NonNull annotation in the return type of getAllPresent.
-    @SuppressWarnings("NullAway")
     var result = new HashMap<K, Expirable<V>>(cache.getAllPresent(keys));
 
     int[] expired = { 0 };

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/LoadingCacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/LoadingCacheProxy.java
@@ -165,7 +165,6 @@ public final class LoadingCacheProxy<K, V> extends CacheProxy<K, V> {
     var future = CompletableFuture.runAsync(() -> {
       try {
         if (replaceExistingValues) {
-          @SuppressWarnings("NullAway")
           Map<K, V> loaded = cacheLoader.orElseThrow().loadAll(keys);
           for (var entry : loaded.entrySet()) {
             putNoCopyOrAwait(entry.getKey(), entry.getValue(), /* publishToWriter= */ false);

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/copy/AbstractCopier.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/copy/AbstractCopier.java
@@ -48,7 +48,7 @@ import org.jspecify.annotations.NullMarked;
  * @author ben.manes@gmail.com (Ben Manes)
  */
 @NullMarked
-@SuppressWarnings({"ImmutableMemberCollection", "JavaUtilDate", "JdkObsolete"})
+@SuppressWarnings({"ImmutableMemberCollection", "JavaUtilDate"})
 public abstract class AbstractCopier<A> implements Copier {
   private static final Map<Class<?>, Function<Object, Object>> JAVA_DEEP_COPY = Map.of(Date.class,
       o -> ((Date) o).clone(), GregorianCalendar.class, o -> ((GregorianCalendar) o).clone());

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/copy/JavaSerializationCopierTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/copy/JavaSerializationCopierTest.java
@@ -123,14 +123,14 @@ public final class JavaSerializationCopierTest {
   }
 
   @Test(dataProvider = "copier")
-  @SuppressWarnings({"JavaUtilDate", "JdkObsolete", "UndefinedEquals"})
+  @SuppressWarnings({"JavaUtilDate", "UndefinedEquals"})
   public void deepCopy_date(Copier copier) {
     var date = new Date();
     assertThat(copy(copier, date)).isEqualTo(date);
   }
 
   @Test(dataProvider = "copier")
-  @SuppressWarnings({"JavaUtilDate", "JdkObsolete"})
+  @SuppressWarnings("JavaUtilDate")
   public void deepCopy_calendar(Copier copier) {
     var calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), US);
     calendar.setTime(new Date());


### PR DESCRIPTION
Found by locally compiling with a build of Error Prone with https://github.com/google/error-prone/pull/4828 applied and a NullAway branch that supports the unused suppression detection.  (Support for JdkObsolete was built into the Error Prone PR)
