### PR TITLE
Attributing Copyrights to contributors in Apache license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2015 Caffeine Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The current copyright license wasn't attributed properly making it invalid. Updating that since we are using your project internally and while making proper attributions on our side, we noticed it. 

We therefore wanted to contribute back proper licensing for you in the process. You can switch it to your own username instead of caffeine contributors if you'd like.

This pull request updates the copyright information in the `LICENSE` file to reflect the correct year and copyright owner.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L190-R190): Updated the copyright notice from a placeholder (`[yyyy] [name of copyright owner]`) to "2015 Caffeine Contributors" for accuracy.