### PR TITLE
Make contents of some AtomicReference variables @Nullable

### DIFF
--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/AsyncTest.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/AsyncTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jspecify.annotations.Nullable;
 import org.mockito.Mockito;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -85,7 +86,7 @@ public final class AsyncTest {
   @Test
   public void getWhenSuccessful_success_async() {
     var future = new CompletableFuture<Integer>();
-    var result = new AtomicReference<Integer>();
+    var result = new AtomicReference<@Nullable Integer>();
     ConcurrentTestHarness.execute(() -> {
       result.set(1);
       result.set(Async.getWhenSuccessful(future));

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/BoundedLocalCacheTest.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/BoundedLocalCacheTest.java
@@ -1305,9 +1305,9 @@ public final class BoundedLocalCacheTest {
     var evictor = Thread.currentThread();
     var started = new AtomicBoolean();
     var writing = new AtomicBoolean();
-    var evictedValue = new AtomicReference<Int>();
-    var previousValue = new AtomicReference<Int>();
-    var removedValues = new AtomicReference<>(Int.valueOf(0));
+    var evictedValue = new AtomicReference<@Nullable Int>();
+    var previousValue = new AtomicReference<@Nullable Int>();
+    var removedValues = new AtomicReference<@Nullable Int>(Int.valueOf(0));
 
     RemovalListener<Int, Int> evictionListener =
         (k, v, cause) -> evictedValue.set(v);
@@ -2742,7 +2742,7 @@ public final class BoundedLocalCacheTest {
   public void putIfAbsent_expireAfterRead(BoundedLocalCache<Int, Int> cache, CacheContext context) {
     var node = cache.data.get(cache.nodeFactory.newLookupKey(context.firstKey()));
     context.ticker().advance(Duration.ofHours(1));
-    var result = new AtomicReference<Int>();
+    var result = new AtomicReference<@Nullable Int>();
     long currentDuration = 1;
     requireNonNull(node);
 

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/issues/Issue568Test.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/issues/Issue568Test.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.Test;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -52,7 +53,7 @@ public final class Issue568Test {
     String val = "val";
     cache.put("key", "val");
 
-    var error = new AtomicReference<RuntimeException>();
+    var error = new AtomicReference<@Nullable RuntimeException>();
     var threads = new ArrayList<Thread>();
     for (int i = 0; i < 10; i++) {
       int name = i;
@@ -89,7 +90,7 @@ public final class Issue568Test {
    */
   @Test
   public void resurrect() throws InterruptedException {
-    var error = new AtomicReference<RuntimeException>();
+    var error = new AtomicReference<@Nullable RuntimeException>();
     Cache<String, Object> cache = Caffeine.newBuilder()
         .weakValues()
         .executor(ConcurrentTestHarness.executor)

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/admission/clairvoyant/Clairvoyant.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/admission/clairvoyant/Clairvoyant.java
@@ -37,6 +37,8 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * {@literal Bélády's} optimal page replacement policy applied as an admission policy by comparing
  * the keys using their next access times.
@@ -44,7 +46,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
  * @author ben.manes@gmail.com (Ben Manes)
  */
 public final class Clairvoyant implements KeyOnlyAdmittor {
-  private static final AtomicReference<Long2ObjectMap<IntList>> snapshot = new AtomicReference<>();
+  private static final AtomicReference<@Nullable Long2ObjectMap<IntList>> snapshot = new AtomicReference<>();
 
   private final Long2ObjectMap<IntPriorityQueue> accessTimes;
   private final PolicyStats policyStats;


### PR DESCRIPTION
This is in preparation for uber/NullAway#1298, which causes new errors to be reported without these annotations.