### PR TITLE
Use shared EMPTY_FEATURES_ARRAY instead of allocating new CompletableFuture[] each time

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
@@ -167,7 +167,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
       return CompletableFuture.completedFuture(emptyMap);
     }
     @SuppressWarnings("rawtypes")
-    CompletableFuture<?>[] array = futures.values().toArray(EMPTY_FEATURES_ARRAY);
+    CompletableFuture<?>[] array = futures.values().toArray(EMPTY_FUTURES_ARRAY);
     return CompletableFuture.allOf(array).thenApply(ignored -> {
       var result = new LinkedHashMap<K, V>(calculateHashMapCapacity(futures.size()));
       futures.forEach((key, future) -> {


### PR DESCRIPTION
This change replaces the dynamic new CompletableFuture[0] array creation with a shared constant EMPTY_FEATURES_ARRAY when calling toArray(...).

Allocating a new zero-length array on every invocation is unnecessary and slightly wasteful. Reusing a cached shared array is a small micro-optimization that avoids repeated allocations