### PR TITLE
Fix build cache relocatability: absolute paths in task inputs

### DIFF
--- a/caffeine/build.gradle.kts
+++ b/caffeine/build.gradle.kts
@@ -99,6 +99,7 @@ configurations.configureEach {
 val compileCodeGenJava by tasks.existing(JavaCompile::class) {
   classpath = files(sourceSets.named("main").map { it.runtimeClasspath + it.output })
   inputs.files(compileJava.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
 
   options.apply {
     compilerArgs.remove("-parameters")
@@ -127,15 +128,22 @@ private fun JavaExec.codeGenerationTask(generator: String, directory: String) {
   mainClass = "com.github.benmanes.caffeine.cache.${generator}FactoryGenerator"
   val outputDir = layout.buildDirectory.dir("generated/sources/$directory")
   classpath(sourceSets.named("javaPoet").map { it.runtimeClasspath })
-  argumentProviders.add { listOf(outputDir.absolutePath().get()) }
+  argumentProviders.add(object : CommandLineArgumentProvider {
+    @get:Internal
+    val outputDirectory: Provider<Directory> = outputDir
+    override fun asArguments() = listOf(outputDirectory.get().asFile.absolutePath)
+  })
   inputs.files(compileJavaPoetJava.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   outputs.cacheIf { true }
   outputs.dir(outputDir)
 }
 
 tasks.named<JavaCompile>("compileJava").configure {
   inputs.files(tasks.named<JavaExec>("generateLocalCaches").map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   inputs.files(tasks.named<JavaExec>("generateNodes").map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   finalizedBy(compileCodeGenJava)
   options.apply {
     compilerArgs.addAll(listOf("-Xlint:-auxiliaryclass", "-Xlint:-exports"))
@@ -144,7 +152,9 @@ tasks.named<JavaCompile>("compileJava").configure {
 
 tasks.named<JavaCompile>("compileTestJava").configure {
   inputs.files(compileCodeGenJava.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   inputs.files(jar.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/caffeine/build.gradle.kts
+++ b/caffeine/build.gradle.kts
@@ -410,6 +410,7 @@ testing.suites {
         useParallelJUnitJupiter()
         val relativeDir = projectDir
         inputs.files(jar.map { it.outputs.files })
+          .withPathSensitivity(PathSensitivity.RELATIVE)
         val jarPath = jar.flatMap { it.archiveFile }.relativePathFrom(relativeDir)
         doFirst { systemProperty("caffeine.osgi.jar", jarPath.get()) }
       }
@@ -421,6 +422,7 @@ tasks.named<Jar>("jar").configure {
   from(sourceSets.named("main").map { it.output })
   from(sourceSets.named("codeGen").map { it.output })
   inputs.files(compileCodeGenJava.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   bundle.bnd(mapOf(
     "Bundle-SymbolicName" to "com.github.ben-manes.caffeine",
     "Import-Package" to "",
@@ -432,7 +434,9 @@ tasks.named<Jar>("jar").configure {
 
 tasks.named<Jar>("sourcesJar").configure {
   inputs.files(generateLocalCaches.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   inputs.files(generateNodes.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   from(sourceSets.named("codeGen").map { it.allSource })
 }
 
@@ -493,6 +497,7 @@ tasks.register<Stress>("stress") {
   description = "Executes a stress test"
   mainClass = "com.github.benmanes.caffeine.cache.Stresser"
   inputs.files(tasks.named<JavaCompile>("compileTestJava").map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   classpath(
     sourceSets.named("codeGen").map { it.runtimeClasspath },
     sourceSets.named("test").map { it.runtimeClasspath })

--- a/gradle/plugins/src/main/kotlin/lifecycle/java-library.caffeine.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/lifecycle/java-library.caffeine.gradle.kts
@@ -1,5 +1,6 @@
 @file:Suppress("PackageDirectoryMismatch", "UnstableApiUsage")
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 
 plugins {
   `java-library`
@@ -112,7 +113,7 @@ tasks.withType<Javadoc>().configureEach {
     use()
     noTimestamp()
     addStringOption("-link-modularity-mismatch", "info")
-    addStringOption("-snippet-path", snippetPath.asFile.absolutePath)
+    // -snippet-path is set in doFirst to avoid absolute path in cache key
     addStringOption("-release", java.toolchain.languageVersion.get().toString())
     links(
       "https://jspecify.dev/docs/api/",
@@ -125,7 +126,12 @@ tasks.withType<Javadoc>().configureEach {
       linksOffline("https://static.javadoc.io/$group/caffeine/$version/",
         relativePath(caffeine.layout.buildDirectory.dir("docs/javadoc")))
       inputs.files(caffeine.tasks.withType<Javadoc>().map { it.outputs.files })
+        .withPathSensitivity(RELATIVE)
     }
+  }
+  doFirst {
+    (options as StandardJavadocDocletOptions)
+      .addStringOption("-snippet-path", snippetPath.asFile.absolutePath)
   }
   javadocTool = javaToolchains.javadocToolFor {
     vendor = java.toolchain.vendor

--- a/gradle/plugins/src/main/kotlin/quality/errorprone.caffeine.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/quality/errorprone.caffeine.gradle.kts
@@ -48,6 +48,7 @@ val downloadCaffeine by tasks.registering {
 
 tasks.withType<JavaCompile>().configureEach {
   inputs.files(downloadCaffeine.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
 
   options.apply {
     errorprone {

--- a/jcache/build.gradle.kts
+++ b/jcache/build.gradle.kts
@@ -190,6 +190,7 @@ tasks.named<Jar>("jar").configure {
 
 tasks.named<Javadoc>("javadoc").configure {
   inputs.files(unzipJCacheJavaDoc.map { it.outputs.files })
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   javadocOptions {
     addBooleanOption("Xdoclint:all,-missing", true)
     linksOffline("https://static.javadoc.io/javax.cache/cache-api/${libs.versions.jcache.get()}/",


### PR DESCRIPTION
## Problem

38 cacheable tasks have absolute paths in their inputs, making the build cache non-relocatable. Builds in different directories produce different cache keys for identical source code, preventing cache reuse across CI agents or different checkout locations.

## Impact

Without these fixes, cache relocatability is completely broken:

| Metric | Before | After |
|---|---|---|
| Build time (`clean assemble`, cached) | **5m 8s** | **35s** |
| Cache hit rate | 28% (15/53) | **94.8%** |
| Avoidance savings | 60s (7.7%) | **800s (94.8%)** |
| Cache misses | 38 | **0** |

Every `clean assemble` on a different machine or CI agent re-executes all 38 cacheable tasks from scratch instead of reusing cached outputs — **~4.5 minutes of wasted compilation per build**.

## Root causes and fixes

### 1. Error Prone jar: absolute path in annotation processor input (30 tasks)

**File:** `gradle/plugins/src/main/kotlin/quality/errorprone.caffeine.gradle.kts`

`inputs.files(downloadCaffeine.map { it.outputs.files })` on every `JavaCompile` task lacks path sensitivity, so Gradle fingerprints the full absolute path of `build/errorprone/caffeine-3.2.3.jar`. This is the **root cause** — it affects all 30 `JavaCompile` tasks across all modules, which cascades to downstream `Javadoc`, `Jar`, and other tasks.

**Fix:** Add `.withPathSensitivity(PathSensitivity.RELATIVE)`.

### 2. Code gen argument providers: absolute output dir in cache key (2 tasks)

**File:** `caffeine/build.gradle.kts`

`generateNodes` and `generateLocalCaches` pass the output directory as a command-line argument via a lambda-based `argumentProviders.add { }`. Gradle treats this as an opaque input, baking the absolute path into the cache key.

**Fix:** Switch to a typed `CommandLineArgumentProvider` with `@Internal` on the output directory property. The output dir is already tracked via `outputs.dir()`.

### 3. Javadoc `-snippet-path`: absolute path at configuration time (5 tasks)

**File:** `gradle/plugins/src/main/kotlin/lifecycle/java-library.caffeine.gradle.kts`

The `-snippet-path` option was set at configuration time with an absolute path, embedding it in `options.extraOptions` in the cache key.

**Fix:** Move to a `doFirst` block so it's resolved at execution time only. Add `RELATIVE` path sensitivity to the snippet path input directory.

### 4. `inputs.files()` on task outputs: missing path sensitivity (multiple tasks)

**File:** `caffeine/build.gradle.kts`, `jcache/build.gradle.kts`

Multiple tasks declare `inputs.files(otherTask.outputs.files)` for ordering/recompilation without `withPathSensitivity(RELATIVE)`, so the absolute paths of output directories pollute the cache key.

**Fix:** Add `.withPathSensitivity(PathSensitivity.RELATIVE)` to all such declarations.

### Not fixed: `jmhJar` (JMH Gradle plugin issue)

The `:caffeine:jmhJar` task has 3 input file properties with absolute path sensitivity, added internally by the JMH Gradle plugin's `createStandardJmhJar`. There is no public API to change their path sensitivity after the fact.

Tracked upstream: https://github.com/melix/jmh-gradle-plugin/issues/283

## Implications

- **No behavioral change.** All tasks execute the same way with the same inputs and outputs. Only cache key computation changes.
- **Cache relocatability restored.** Different directories produce identical cache keys.
- **Risk is low.** `RELATIVE` is the standard path sensitivity for build outputs.

## Verification

Verified via [Develocity build validation experiments](https://github.com/gradle/develocity-oss-projects/actions/runs/23341741533) — all 3 experiments pass with `failIfNotFullyCacheable: true`.

- [Exp3 scan comparison](https://ge.solutions-team.gradle.com/c/5sdufp3azkv2m/ms3mytovuaaj6/task-inputs) — no task input differences for cacheable tasks.