### PR TITLE
Simplify cache name snapshot creation

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.ref.WeakReference;
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -182,7 +183,8 @@ public final class CacheManagerImpl implements CacheManager {
   }
 
   @Override
-  public List<String> getCacheNames() {
+  @SuppressWarnings("PreferredInterfaceType")
+  public Collection<String> getCacheNames() {
     requireNotClosed();
     return List.copyOf(caches.keySet());
   }

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.ref.WeakReference;
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -183,7 +182,7 @@ public final class CacheManagerImpl implements CacheManager {
   }
 
   @Override
-  public Collection<String> getCacheNames() {
+  public List<String> getCacheNames() {
     requireNotClosed();
     return List.copyOf(caches.keySet());
   }

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheManagerImpl.java
@@ -19,9 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.ref.WeakReference;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -186,7 +185,7 @@ public final class CacheManagerImpl implements CacheManager {
   @Override
   public Collection<String> getCacheNames() {
     requireNotClosed();
-    return Collections.unmodifiableCollection(new ArrayList<>(caches.keySet()));
+    return List.copyOf(caches.keySet());
   }
 
   @Override


### PR DESCRIPTION
### Summary

This PR simplifies `CacheManagerImpl#getCacheNames()` by replacing the existing `ArrayList` + `Collections.unmodifiableCollection(...)` usage with `List.copyOf(...)`.

### Motivation

The current implementation creates a snapshot of the cache names and wraps it as an unmodifiable collection:

```java
Collections.unmodifiableCollection(new ArrayList<>(caches.keySet()))
```
List.copyOf(...) provides the same intent more directly by creating an unmodifiable snapshot of the given collection.

### Changes


```java
return List.copyOf(caches.keySet());
```

This reduces boilerplate and improves readability without changing the method signature or intended behavior.

### Notes

- No public API behavior is changed.
- The method signature remains `Collection<String>` to preserve public binary compatibility.
- The returned collection remains unmodifiable.
- The cache names are still returned as a snapshot.
- This change is limited to JCache cache-name snapshot creation.
- No core cache eviction or performance-sensitive logic is changed.

### Validation

- [x] `./gradlew :jcache:test`
- [x] `./gradlew assemble`