### PR TITLE
Expose --outputDir option on simulate Gradle task

### DIFF
--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -133,6 +133,8 @@ abstract class Simulate @Inject constructor(
   abstract val theme: Property<String>
   @get:Input @get:Option(option = "title", description = "The chart title")
   abstract val title: Property<String>
+  @get:Input @get:Option(option = "outputDir", description = "The output directory")
+  abstract val outputDir: Property<String>
   @get:OutputDirectory
   val reportDir: Provider<Directory> = projectLayout.buildDirectory.dir("reports/$name")
 
@@ -144,12 +146,13 @@ abstract class Simulate @Inject constructor(
     metric.convention("Hit Rate")
     theme.convention("light")
     title.convention("")
+    outputDir.convention(reportDir.map { it.asFile.path })
     argumentProviders.add {
       buildList {
         if (maximumSize.get().isNotEmpty()) {
           addAll(listOf("--maximumSize", maximumSize.get().joinToString(",")))
         }
-        addAll(listOf("--outputDir", reportDir.get().asFile.path))
+        addAll(listOf("--outputDir", outputDir.get()))
         addAll(listOf("--metric", metric.get()))
         addAll(listOf("--title", title.get()))
         addAll(listOf("--theme", theme.get()))


### PR DESCRIPTION
## Summary
Add a `--outputDir` CLI option to the `simulator:simulate` Gradle task so callers can override the hardcoded `build/reports/simulate/` destination. Default behavior unchanged.

## Motivation
`Simulate.java:72-73` already declares `@Option(names = "--outputDir", required = true)` on the picocli entry point, but the Gradle task class (`simulator/build.gradle.kts:133-149`) hardcoded `reportDir` and offered no `@Option` to override it. The Java side intended this to be configurable; the Gradle side never plumbed it through. This blocks running multiple invocations against one checkout without colliding artifacts.

## Changes
- Add `outputDir: Property<String>` with `@get:Input @get:Option(option = "outputDir")` on the `Simulate` JavaExec task.
- Default it via `convention(reportDir.map { it.asFile.path })` so omitting the flag preserves the existing path.
- Argument provider now reads `outputDir.get()` instead of `reportDir.get().asFile.path`.

## Notes
- `reportDir` remains as the `@OutputDirectory` provider (default path) for backward compatibility with anything querying task outputs. The task is already configured `upToDateWhen { false }` and `cacheIf { false }`, so the override's interaction with incremental-build tracking is a non-issue.
- Pattern matches the existing `@get:Input @get:Option` declarations on `maximumSize`, `metric`, `theme`, `title` in the same class.

## Validation
- `./gradlew help --task simulator:simulate` lists `--outputDir` alongside the other options.
- `./gradlew simulator:simulate --outputDir /tmp/test --maximumSize 512` wrote `/tmp/test/hit_rate_512.csv`.
- `./gradlew simulator:simulate --maximumSize 512` (no flag) wrote `simulator/build/reports/simulate/hit_rate_512.csv` — same as before.

Fixes #1958