### PR TITLE
Fix LongPreprocessor stripping underscores from unrelated args

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Simulate.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/Simulate.java
@@ -148,7 +148,10 @@ public final class Simulate implements Runnable {
   private static final class LongPreprocessor implements IParameterPreprocessor {
     @Override public boolean preprocess(Stack<String> args,
         CommandSpec commandSpec, ArgSpec argSpec, Map<String, Object> info) {
-      args.replaceAll(arg -> arg.replace("_", ""));
+      if (!args.isEmpty()) {
+        var optionValue = args.pop();
+        args.push(optionValue.replace("_", ""));
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Summary
`LongPreprocessor` (used by `--maximumSize` to allow `512_000`-style values) called `args.replaceAll(arg -> arg.replace("_", ""))`, which mutated **every** remaining arg on picocli's parse stack — not just the value being bound to `--maximumSize`. Any unrelated arg containing `_` (e.g. `--outputDir=/tmp/foo_bar/...`) got its underscores silently deleted, so reports were written to a different path than the caller passed.

## Reproduction
```
./gradlew simulator:simulate \
  --maximumSize=512 \
  --outputDir=/tmp/foo_bar_baz
```
The simulator writes `hit_rate_512.csv` to `/tmp/foobarbaz/` instead of `/tmp/foo_bar_baz/`.

## Fix
Only mutate the value picocli is about to bind to the option (top of the stack), leaving the rest of the parse stack untouched:

```java
if (!args.isEmpty()) {
  var optionValue = args.pop();
  args.push(optionValue.replace("_", ""));
}
```

Behavior for the supported case (`--maximumSize 512_000` and `--maximumSize=512_000`, including the comma-split form like `512_000,1_000_000`) is unchanged — the value still arrives at the parser with underscores stripped.

## Validation
- `./gradlew simulator:test` — green.
- `./gradlew simulator:build -Pspotbugs -Ppmd` — green.
- `./gradlew simulator:simulate --maximumSize=512 --outputDir=/tmp/foo_bar_baz` writes to `/tmp/foo_bar_baz/hit_rate_512.csv` (previously: `/tmp/foobarbaz/`).