### PR TITLE
parse hex addresses as unsigned in address trace readers

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/AddressTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/AddressTraceReader.java
@@ -37,6 +37,6 @@ public final class AddressTraceReader extends TextTraceReader implements KeyOnly
     return lines()
         .map(line -> line.split(" ", 3)[1])
         .map(address -> address.substring(2))
-        .mapToLong(address -> Long.parseLong(address, 16));
+        .mapToLong(address -> Long.parseUnsignedLong(address, 16));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/penalties/AddressPenaltiesTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/address/penalties/AddressPenaltiesTraceReader.java
@@ -65,7 +65,7 @@ public final class AddressPenaltiesTraceReader extends TextTraceReader {
     return lines()
         .map(line -> line.split(" ", 5))
         .map(split -> AccessEvent.forKeyAndPenalties(
-            Long.parseLong(split[1].substring(2), 16),
+            Long.parseUnsignedLong(split[1].substring(2), 16),
             Double.parseDouble(split[3]),
             Double.parseDouble(split[4])));
   }


### PR DESCRIPTION
The address readers feed each trace line through Long.parseLong(hex, 16) to build the cache key, but a hardware address is an unsigned 64-bit value. Any address with the top bit set, anything from 0x8000000000000000 upwards, is outside the signed long range, so parseLong throws a NumberFormatException and the whole event stream aborts partway through the trace. I hit this while pointing the penalties reader at a trace captured from a 64-bit host; the run died on the first high address rather than reporting a parse warning, which is why it took a moment to trace back to the radix conversion.

Switching both sites to Long.parseUnsignedLong keeps the full 64-bit address as the key, with the high half wrapping into a negative long exactly as the existing BigInteger(value, 16).longValue() readers (object-store, gradle) already do. The conversion belongs in the reader since that is the only place the textual address is turned into the long key the policies consume.
