### PR TITLE
expand camelab requests as contiguous sector keys

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/camelab/CamelabTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/camelab/CamelabTraceReader.java
@@ -27,7 +27,6 @@ import com.github.benmanes.caffeine.cache.simulator.parser.TraceReader.KeyOnlyTr
  * @author ben.manes@gmail.com (Ben Manes)
  */
 public final class CamelabTraceReader extends TextTraceReader implements KeyOnlyTraceReader {
-  static final long BLOCK_SIZE = 512;
 
   public CamelabTraceReader(String filePath) {
     super(filePath);
@@ -42,13 +41,9 @@ public final class CamelabTraceReader extends TextTraceReader implements KeyOnly
         return LongStream.empty();
       }
 
-      long startAddress = Long.parseLong(array[2]);
-      int requestSize = Integer.parseInt(array[3]);
-      long[] blocks = new long[requestSize];
-      for (int i = 0; i < requestSize; i++) {
-        blocks[i] = startAddress + (i * BLOCK_SIZE);
-      }
-      return LongStream.of(blocks);
+      long startBlock = Long.parseLong(array[2]);
+      int sequence = Integer.parseInt(array[3]);
+      return LongStream.range(startBlock, startBlock + sequence);
     });
   }
 }


### PR DESCRIPTION
The Camelab reader expands a multi-sector request by looping over the request size and emitting startAddress + i * 512 for each block, but the documented trace format records both the address and the request size in 512-byte sectors. A four-sector read at LBA 100 therefore covers sectors 100 through 103, yet the reader produced 100, 612, 1124 and 1636. I noticed the gaps while comparing Camelab behaviour against the other block readers; the 512-wide spacing meant overlapping requests could never collide, so every simulation over a Camelab trace under-reported its hit rate and inflated the working set.

The address is already a sector index, so the stride multiply was the bug: it mixed a sector base with a byte step. Every sibling block reader (arc, umass storage, snia systor/enterprise/k5cloud) treats its size field as a count and ranges over contiguous blocks, and Camelab was the only one multiplying the index by the sector size. Switching to LongStream.range over the sector span keeps the conversion in the reader where the textual fields become the long keys the policies consume, and drops the per-request array allocation along the way.