### PR TITLE
read the object size as the weight in object store traces

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/keyvalue/ObjectStoreTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/keyvalue/ObjectStoreTraceReader.java
@@ -18,7 +18,6 @@ package com.github.benmanes.caffeine.cache.simulator.parser.snia.keyvalue;
 import static com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic.WEIGHTED;
 
 import java.math.BigInteger;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -50,14 +49,9 @@ public final class ObjectStoreTraceReader extends TextTraceReader {
         .map(line -> line.split(" "))
         .filter(array -> array[1].equals("REST.GET.OBJECT"))
         .map(array -> {
-          long start = Long.parseLong(array[4]);
-          long end = Long.parseLong(array[5]);
-          int weight = Ints.saturatedCast(end - start);
-          if (weight <= 0) {
-            return null;
-          }
           long key = new BigInteger(array[2], 16).longValue();
+          int weight = Ints.saturatedCast(Long.parseLong(array[3]));
           return AccessEvent.forKeyAndWeight(key, weight);
-        }).filter(Objects::nonNull).map(Objects::requireNonNull);
+        });
   }
 }


### PR DESCRIPTION
The IBM ObjectStore records carry the object size as their own column, ahead of the offsets:

```
<time stamp> <request type> <object ID> <size of object> <beginning offset> <ending offset>
1232488 REST.GET.OBJECT 95d363d3fbdc0b03 1168 0 1167
```

`ObjectStoreTraceReader.events` was instead deriving the weight from the offsets as `end - start`, which came out a byte short of that size column on every GET, and where `start == end` (a single-byte read) collapsed to zero and got discarded by the `weight <= 0` guard. Per the [README](https://iotta.snia.org/traces/key-value/36305) the offsets are an inclusive range, so the documented object size is the cleaner source: read it directly from the size column instead. That drops the offset arithmetic, the guard, and the null-filtering tail, and lines this reader up with how `CambridgeTraceReader` reads its size field.