### PR TITLE
Expose isPendingEviction on the public Policy interface

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -4250,6 +4250,9 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
       Node<K, V> node = cache.data.get(cache.nodeFactory.newLookupKey(key));
       return (node == null) ? null : cache.nodeToCacheEntry(node, transformer, node.getWeight());
     }
+    @Override public boolean isPendingEviction(K key) {
+      return cache.isPendingEviction(key);
+    }
     @SuppressWarnings("Java9CollectionFactory")
     @Override public Map<K, CompletableFuture<V>> refreshes() {
       var refreshes = cache.refreshes;

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Policy.java
@@ -80,6 +80,26 @@ public interface Policy<K, V> {
   }
 
   /**
+   * Returns whether the entry associated with {@code key} is logically expired (invisible to all
+   * cache read operations) but has not yet been physically removed from the cache or had its
+   * removal listener notified. This window exists because expiration is evaluated on every read
+   * path, but physical removal and listener notification happen asynchronously in the maintenance
+   * cycle.
+   *
+   * <p>The result is a best-effort snapshot taken without holding the eviction lock. A {@code true}
+   * result means the entry was pending eviction at the moment of the call, but the maintenance task
+   * may concurrently complete the eviction. A {@code false} result means the entry is either
+   * absent, logically alive, or already fully purged.
+   *
+   * @param key the key to inspect
+   * @return {@code true} if the entry is logically expired and awaiting physical removal
+   * @throws NullPointerException if the specified key is null
+   */
+  default boolean isPendingEviction(K key) {
+    return false;
+  }
+
+  /**
    * Returns an unmodifiable snapshot {@link Map} view of the in-flight refresh operations.
    *
    * @return a snapshot view of the in-flight refresh operations


### PR DESCRIPTION
# Expose `isPendingEviction` on the public `Policy` interface

## CLA

Signed at https://cla-assistant.io/ben-manes/caffeine ✓

---

## What and why

`isPendingEviction(K key)` already existed on the internal `LocalCache` interface
with correct implementations in both `BoundedLocalCache` and `UnboundedLocalCache`,
but was never reachable from the public `Policy` API.

Caffeine decouples logical expiration from physical eviction: `getIfPresent` returns
`null` as soon as a timestamp threshold is crossed, but the node stays in the
underlying `ConcurrentHashMap` until the background maintenance cycle drains the
buffers and fires the `RemovalListener`. This gap is normally sub-millisecond but
can reach ~1 s under a custom scheduler. Without this method, callers have no way
to distinguish a genuine miss from a transitional one, making it impossible to
avoid redundant fallback work (e.g. thundering-herd database reads) during the gap.

## Changes

**`Policy.java`** — new `default` method on `Policy<K, V>`:

```java
/**
 * Returns whether the entry for {@code key} is logically expired but has not
 * yet been physically removed or had its removal listener notified. The result
 * is a best-effort snapshot without holding the eviction lock; a {@code true}
 * result may race with a concurrent maintenance cycle completing the eviction.
 */
default boolean isPendingEviction(K key) {
    return false;
}
```

The default is `false` rather than `UnsupportedOperationException` because it is
always the safe answer for unbounded or non-expiring caches.

**`BoundedLocalCache.java`** — one-line override in `BoundedPolicy` delegating to
the existing internal implementation:

```java
@Override public boolean isPendingEviction(K key) {
    return cache.isPendingEviction(key);
}
```

## Usage

```java
if (cache.policy().isPendingEviction(key)) {
    // RemovalListener has not fired yet — piggyback on the in-flight reload
    // rather than issuing a redundant database call
}
```

## Notes

- `BoundedLocalCache.isPendingEviction` (unchanged) reads node state lock-free,
  consistent with the posture already accepted by other `BoundedPolicy` methods
  such as `weightOf`.
- `UnboundedLocalCache.isPendingEviction` (unchanged) returns `false` — correct,
  since unbounded caches never expire entries.
- 2 files changed, 23 insertions(+).

Closes #1966