### PR TITLE
replay cachelib op_count repeated accesses

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/cachelib/CachelibTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/cachelib/CachelibTraceReader.java
@@ -17,6 +17,7 @@ package com.github.benmanes.caffeine.cache.simulator.parser.cachelib;
 
 import static com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic.WEIGHTED;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -47,7 +48,10 @@ public final class CachelibTraceReader extends TextTraceReader {
     return lines().skip(1)
         .map(line -> line.split(","))
         .filter(array -> array[1].equals("GET"))
-        .map(array -> AccessEvent.forKeyAndWeight(
-            Long.parseLong(array[0]), Integer.parseInt(array[2])));
+        .flatMap(array -> {
+          var event = AccessEvent.forKeyAndWeight(
+              Long.parseLong(array[0]), Integer.parseInt(array[2]));
+          return Collections.nCopies(Integer.parseInt(array[3]), event).stream();
+        });
   }
 }


### PR DESCRIPTION
While checking the cachelib reader against the FB HW eval trace format I noticed events() maps each row to a single access and drops the op_count column, even though the reader's own header comment lists it. In that format op_count is the number of times the operation was issued for that key within the sample window; cachelib's own KVReplayGenerator parses it into repeats_ and re-runs the request that many times. Collapsing every row to one access loses the per-key frequency, so any GET with op_count > 1 is undercounted, which skews the reported hit rate and starves the TinyLFU admission sketch of the access counts it is meant to learn from.

Replaced the map with a flatMap that repeats each GET event op_count times. Keeping the expansion in the reader follows the convention that per-policy concerns such as correlated-reference dedup belong in record(), so the reader should emit the accesses faithfully and leave any collapsing to the policy. On a small sample whose GET rows carry op_count 3, 1 and 4 the reader now yields 8 accesses rather than 3, with the per-key counts matching the column.