### PR TITLE
include the asu in umass storage trace keys

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,6 +4,7 @@ Adoptium
 Ams
 amsgrad
 appname
+asu
 Autobuild
 awaitility
 Azul

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
@@ -42,13 +42,16 @@ public final class StorageTraceReader extends TextTraceReader implements KeyOnly
       if (array.length <= 4) {
         return LongStream.empty();
       }
+      char readWrite = Character.toLowerCase(array[3].charAt(0));
+      if (readWrite == 'w') {
+        return LongStream.empty();
+      }
+      long asu = Long.parseLong(array[0]);
       long startBlock = Long.parseLong(array[1]);
       int size = Integer.parseInt(array[2]);
       int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
-      char readWrite = Character.toLowerCase(array[3].charAt(0));
-      return (readWrite == 'w')
-          ? LongStream.empty()
-          : LongStream.range(startBlock, startBlock + sequence);
+      long key = (asu << 40) | (startBlock & 0xFFFFFFFFFFL);
+      return LongStream.range(key, key + sequence);
     });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
@@ -24,7 +24,7 @@ import com.google.common.math.IntMath;
 
 /**
  * A reader for the trace files provided by the
- * <a href="https://traces.cs.umass.edu/index.php/Storage/Storage">UMass Trace Repository</a>.
+ * <a href="https://traces.cs.umass.edu/docs/traces/storage">UMass Trace Repository</a>.
  *
  * @author ben.manes@gmail.com (Ben Manes)
  */


### PR DESCRIPTION
StorageTraceReader builds each cache key from the LBA column alone, but the UMass SPC traces are multi-volume. Column 0 is the ASU (application storage unit) and the LBA in column 1 is an offset within that ASU, so it restarts at zero for every volume. Decompressing Financial1 and tallying the columns, the first ~323k records span 24 distinct ASUs (0-23) and 15,530 LBAs turn up under more than one ASU; LBA 0 alone is read on ASUs 0, 19, 20 and 22. Each of those collapses onto a single key, so unrelated blocks on separate volumes get scored as cache hits and the hit rate reported for these traces is inflated.

Fold the ASU into the high bits of the key and leave the per-ASU block number in the low 40 bits, the same encoding TencentBlockTraceReader already uses for its volume id (the largest block I saw was about 1.2M, well inside that range). Keeping it in the reader means the volume identity travels with the key for every policy rather than each one having to rebuild it.
