### PR TITLE
match the whole op field in the baleen trace reader

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/baleen/BaleenTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/baleen/BaleenTraceReader.java
@@ -40,7 +40,7 @@ public final class BaleenTraceReader extends TextTraceReader implements KeyOnlyT
     return lines()
         .dropWhile(line -> line.startsWith("#"))
         .map(line -> line.split(" ", 6))
-        .filter(line -> isRead(line[4].charAt(0)))
+        .filter(line -> isRead(line[4]))
         .flatMapToLong(line -> {
           long block = Long.parseLong(line[0]);
           long byteOffset = Long.parseLong(line[1]);
@@ -54,7 +54,7 @@ public final class BaleenTraceReader extends TextTraceReader implements KeyOnlyT
         });
   }
 
-  private static boolean isRead(char operation) {
-    return (operation == '1') || (operation == '2') || (operation == '5');
+  private static boolean isRead(String operation) {
+    return operation.equals("1") || operation.equals("2") || operation.equals("5");
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/baleen/BaleenTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/baleen/BaleenTraceReader.java
@@ -20,6 +20,7 @@ import java.util.stream.LongStream;
 
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.parser.TraceReader.KeyOnlyTraceReader;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.math.IntMath;
 
 /**
@@ -29,6 +30,7 @@ import com.google.common.math.IntMath;
  * @author ben.manes@gmail.com (Ben Manes)
  */
 public final class BaleenTraceReader extends TextTraceReader implements KeyOnlyTraceReader {
+  private static final ImmutableSet<String> READ_OPERATIONS = ImmutableSet.of("1", "2", "5");
   private static final int SEGMENT_SIZE = 128 * 1024;
 
   public BaleenTraceReader(String filePath) {
@@ -40,7 +42,7 @@ public final class BaleenTraceReader extends TextTraceReader implements KeyOnlyT
     return lines()
         .dropWhile(line -> line.startsWith("#"))
         .map(line -> line.split(" ", 6))
-        .filter(line -> isRead(line[4]))
+        .filter(line -> READ_OPERATIONS.contains(line[4]))
         .flatMapToLong(line -> {
           long block = Long.parseLong(line[0]);
           long byteOffset = Long.parseLong(line[1]);
@@ -52,9 +54,5 @@ public final class BaleenTraceReader extends TextTraceReader implements KeyOnlyT
           long startKey = (((long) Long.hashCode(block)) << 32) | startSegment;
           return LongStream.range(startKey, startKey + sequence);
         });
-  }
-
-  private static boolean isRead(String operation) {
-    return operation.equals("1") || operation.equals("2") || operation.equals("5");
   }
 }


### PR DESCRIPTION
`BaleenTraceReader` picks the read requests out with `isRead(line[4].charAt(0))`, looking only at the first character of the op column. I went back to BCacheSim to pin down that field: it reads the op as `int(parts[4])` and maps it onto an `OpType` enum (`GET_TEMP=1`, `GET_PERM=2`, `PUT_TEMP=3`, `PUT_PERM=4`, `GET_NOT_INIT=5`, `PUT_NOT_INIT=6`, `UNKNOWN=100`), where the reads are exactly `{1, 2, 5}`. The leading-character test holds for the single-digit codes but trips on the one multi-digit value: `100` begins with `1`, so an `UNKNOWN` record is taken for a `GET_TEMP` and admitted as a cache read.

Comparing the whole op token keeps that case out. The distinction lives in the full value, so the filter has to look at all of it; once it is cut down to a leading character `100` cannot be told apart from `1`. Any Baleen trace carrying `UNKNOWN` operations would otherwise feed phantom requests into the run and skew the reported hit rate. The PUT codes are unaffected only because none of them starts with a read digit.