### PR TITLE
expand cambridge reads into contiguous block keys

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/cambridge/CambridgeTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/cambridge/CambridgeTraceReader.java
@@ -15,14 +15,12 @@
  */
 package com.github.benmanes.caffeine.cache.simulator.parser.snia.cambridge;
 
-import static com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic.WEIGHTED;
-
-import java.util.Set;
-import java.util.stream.Stream;
+import java.math.RoundingMode;
+import java.util.stream.LongStream;
 
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
-import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
-import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
+import com.github.benmanes.caffeine.cache.simulator.parser.TraceReader.KeyOnlyTraceReader;
+import com.google.common.math.IntMath;
 
 /**
  * A reader for the SNIA MSR Cambridge trace files provided by
@@ -30,23 +28,22 @@ import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic
  *
  * @author ben.manes@gmail.com (Ben Manes)
  */
-public final class CambridgeTraceReader extends TextTraceReader {
+public final class CambridgeTraceReader extends TextTraceReader implements KeyOnlyTraceReader {
+  static final int BLOCK_SIZE = 512;
 
   public CambridgeTraceReader(String filePath) {
     super(filePath);
   }
 
   @Override
-  public Set<Characteristic> characteristics() {
-    return Set.of(WEIGHTED);
-  }
-
-  @Override
-  public Stream<AccessEvent> events() {
+  public LongStream keys() {
     return lines()
         .map(line -> line.split(","))
         .filter(array -> array[3].equals("Read"))
-        .map(array -> AccessEvent.forKeyAndWeight(
-            Long.parseLong(array[4]), Integer.parseInt(array[5])));
+        .flatMapToLong(array -> {
+          long startBlock = Long.parseLong(array[4]) / BLOCK_SIZE;
+          int sequence = IntMath.divide(Integer.parseInt(array[5]), BLOCK_SIZE, RoundingMode.UP);
+          return LongStream.range(startBlock, startBlock + sequence);
+        });
   }
 }


### PR DESCRIPTION
Picking up the Cambridge follow-up we flagged on the CameLab PR (#1963). The MSR Cambridge reader emits a single `forKeyAndWeight(offset, size)` per read, so the cache key is the raw byte offset and the request size only ever lands as the entry weight. The offset and size columns are both in bytes, so two reads that touch the same on-disk sectors at different byte offsets never share a key, and the simulated hit rate is undercounted. Walking a small sample makes it obvious: reads of 4096 bytes at offset 0 and at offset 512 overlap on sectors 1..7, but the reader keys them as 0 and 512 with zero reuse between them. Every other storage reader here (arc, umass storage, snia systor, camelab) instead maps a request onto the contiguous block range, which is why the Cambridge request counts sat an order of magnitude apart in that discussion.

This brings it in line with `StorageTraceReader`: divide the byte offset by 512 for the starting sector and range over `ceil(size / 512)` contiguous keys, dropping to `KeyOnlyTraceReader` since the per-block expansion replaces the per-request weight. With both readers expanding into the same sector key space, overlapping requests can finally collide and the reuse the trace actually contains shows up in the results.