### PR TITLE
include the key size in cachelib trace weights

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/cachelib/CachelibTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/cachelib/CachelibTraceReader.java
@@ -49,8 +49,8 @@ public final class CachelibTraceReader extends TextTraceReader {
         .map(line -> line.split(","))
         .filter(array -> array[1].equals("GET"))
         .flatMap(array -> {
-          var event = AccessEvent.forKeyAndWeight(
-              Long.parseLong(array[0]), Integer.parseInt(array[2]));
+          int weight = Integer.parseInt(array[2]) + Integer.parseInt(array[4]);
+          var event = AccessEvent.forKeyAndWeight(Long.parseLong(array[0]), weight);
           return Collections.nCopies(Integer.parseInt(array[3]), event).stream();
         });
   }


### PR DESCRIPTION
I was lining the key/value readers up against their formats and the cachelib one stood out: events() weights each GET by the size column on its own and never touches the key_size column the header comment right above it documents. In the cachelib cachebench trace size is the value size and key_size is a separate field holding the key string's byte length, so the footprint of a stored item is the two summed. Every entry is recorded light by its key size, and on the small-value records that dominate these traces that is a large slice of the real cost: a 50 byte value with a 40 byte key is scored at 50 instead of 90.

Sum size and key_size when building the event so the weight reflects what the cache actually holds. The sibling TwitterTraceReader already adds the key and value sizes for the same memcached-style trace, so reading the documented column here simply brings the two readers back into line. Left as is the weighted policies run against an understated size distribution and the byte budget stretches over more entries than the trace implies, quietly tilting admission and eviction towards small-value, large-key objects.