### PR TITLE
include the rendered size in tencent photo trace keys

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/TencentPhotoTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/TencentPhotoTraceReader.java
@@ -51,9 +51,12 @@ public final class TencentPhotoTraceReader extends TextTraceReader {
         .map(line -> line.split(" "))
         .filter(array -> array[2].equals(JPEG_FORMAT) || array[2].equals(WEBP_FORMAT))
         .map(array -> {
-          long key = Hashing.murmur3_128().hashBytes(
-              BaseEncoding.base16().lowerCase().decode(array[1])).asLong();
-          return AccessEvent.forKeyAndWeight(key, Integer.parseInt(array[4]));
+          int weight = Integer.parseInt(array[4]);
+          long key = Hashing.murmur3_128().newHasher()
+              .putBytes(BaseEncoding.base16().lowerCase().decode(array[1]))
+              .putInt(weight)
+              .hash().asLong();
+          return AccessEvent.forKeyAndWeight(key, weight);
         });
   }
 }


### PR DESCRIPTION
TencentPhotoTraceReader keys each request off the photo ID checksum alone, but the SNIA Tencent Photo trace serves several rendered variants of one photo under that single checksum, with the size category (l/a/o/m/c/b) and the return-size column telling them apart. Dropping the size from the key collapses those distinct blobs onto one entry. In the sample trace the photo 00be09f1d17efd0aa8c90a3c2ef567df12d63dfb is fetched both as a 21,191 byte thumbnail (spec c) and a 2,227,371 byte full image (spec b); the reader emits one key for both, so a thumbnail request scores as a hit on the cached full image and the per-key weight oscillates between the two sizes. Left unfixed this overstates the hit rate on these traces and feeds an unstable weight into the WEIGHTED size-based eviction, since the same key keeps changing footprint.

Folding the return size into the key hash makes each rendered variant its own entry, which is where the discrimination belongs, the reader is the only place that still sees both the checksum and the size. The sibling AdaptSizeTraceReader already does exactly this (it hashes key+weight for the identical id, different size case), so this just brings the photo reader in line with it. I confirmed against the SNIA readme and a sample subtrace that the checksum repeats across size categories, and a before/after of the key hash shows the two records above separating from one key into two.