### PR TITLE
include the volume id in k5cloud trace keys

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/K5cloudTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/K5cloudTraceReader.java
@@ -41,10 +41,12 @@ public final class K5cloudTraceReader extends TextTraceReader implements KeyOnly
         .map(line -> line.split(","))
         .filter(array -> array[2].charAt(0) == 'R')
         .flatMapToLong(array -> {
+          int volumeId = Integer.parseInt(array[0]);
           long offset = Long.parseLong(array[3]);
           long startBlock = (offset / BLOCK_SIZE);
           int sequence = IntMath.divide(Integer.parseInt(array[4]), BLOCK_SIZE, RoundingMode.UP);
-          return LongStream.range(startBlock, startBlock + sequence);
+          long key = (((long) volumeId) << 40) | (startBlock & 0xFFFFFFFFFFL);
+          return LongStream.range(key, key + sequence);
     });
   }
 }


### PR DESCRIPTION
K5cloudTraceReader keys each read off the byte offset alone, but the SNIA K5cloud format carries the virtual storage volume id in the first column of every record. A single dataset file interleaves roughly a thousand volumes and the offset restarts at zero on each one, so two reads at the same offset on different volumes resolve to the same block keys. Lining a dataset up against the format description, blocks that live on separate volumes are scored as cache hits, which inflates the reported hit rate.

Fold the volume id into the high bits of the key the way the sibling TencentBlockTraceReader in this package already does, with the per-volume block left in the low 40 bits. Composing the key inside the reader keeps the volumes disjoint at the source, so no policy has to be taught that this trace mixes several volumes together.