### PR TITLE
spread systor response time across the request's blocks

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/systor/SystorTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/systor/SystorTraceReader.java
@@ -54,8 +54,8 @@ public final class SystorTraceReader extends TextTraceReader {
         .flatMap(array -> {
           int size = Integer.parseInt(array[5]);
           long startBlock = Long.parseLong(array[4]) / BLOCK_SIZE;
-          double responseTime = 1000 * Double.parseDouble(array[1]);
           int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
+          double responseTime = (1000 * Double.parseDouble(array[1])) / sequence;
           return LongStream.range(startBlock, startBlock + sequence)
               .mapToObj(key -> AccessEvent.forKeyAndPenalties(key, 0, responseTime));
         });


### PR DESCRIPTION
SystorTraceReader expands a multi-block read into one access per 512-byte block, but it hands the whole request's response time to every block as the miss penalty. An 8-block (4 KiB) read whose I/O took 2 ms is then replayed as eight separate misses each costing 2 ms, totalling 16 ms for a request the trace measured at 2 ms. The response time is the latency of one physical I/O covering all of the blocks, not of each block on its own.

missPenalty() feeds the cost-aware greedy-dual policies (CAMP, GDSF, GDWheel) and the average-miss-penalty stat, so leaving it unscaled inflates each block's fetch cost by the block count and biases those policies towards the blocks of large requests. Dividing the response time by the block count shares the request's latency evenly across its blocks, which keeps the total attributed latency equal to the measured value and matches how the reader originally apportioned it.