### PR TITLE
include the disk number in snia enterprise trace keys

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/enterprise/EnterpriseTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/enterprise/EnterpriseTraceReader.java
@@ -51,8 +51,8 @@ public final class EnterpriseTraceReader
 
           long startBlock = byteOffset / BLOCK_SIZE;
           int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
-          long key = (((long) diskNum) << 40) | (startBlock & 0xFFFFFFFFFFL);
-          return LongStream.range(key, key + sequence);
+          return LongStream.range(0, sequence)
+              .map(i -> (((long) diskNum) << 40) | ((startBlock + i) & 0xFFFFFFFFFFL));
         });
   }
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/enterprise/EnterpriseTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/enterprise/EnterpriseTraceReader.java
@@ -43,14 +43,16 @@ public final class EnterpriseTraceReader
     return lines()
         .dropWhile(new SkipHeader())
         .filter(line -> line.stripLeading().startsWith("DiskRead,"))
-        .map(line -> line.split(",", 8))
+        .map(line -> line.split(",", 10))
         .flatMapToLong(line -> {
           long byteOffset = Long.parseLong(line[5].strip().substring(2), 16);
           int size = Integer.parseInt(line[6].strip().substring(2), 16);
+          int diskNum = Integer.parseInt(line[8].strip());
 
           long startBlock = byteOffset / BLOCK_SIZE;
           int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
-          return LongStream.range(startBlock, startBlock + sequence);
+          long key = (((long) diskNum) << 40) | (startBlock & 0xFFFFFFFFFFL);
+          return LongStream.range(key, key + sequence);
         });
   }
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/K5cloudTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/K5cloudTraceReader.java
@@ -45,8 +45,8 @@ public final class K5cloudTraceReader extends TextTraceReader implements KeyOnly
           long offset = Long.parseLong(array[3]);
           long startBlock = (offset / BLOCK_SIZE);
           int sequence = IntMath.divide(Integer.parseInt(array[4]), BLOCK_SIZE, RoundingMode.UP);
-          long key = (((long) volumeId) << 40) | (startBlock & 0xFFFFFFFFFFL);
-          return LongStream.range(key, key + sequence);
+          return LongStream.range(0, sequence)
+              .map(i -> (((long) volumeId) << 40) | ((startBlock + i) & 0xFFFFFFFFFFL));
     });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/TencentBlockTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/parallel/TencentBlockTraceReader.java
@@ -42,8 +42,8 @@ public final class TencentBlockTraceReader extends TextTraceReader implements Ke
           long offset = Long.parseLong(array[1]);
           int sequence = Integer.parseInt(array[2]);
           int volumeId = Integer.parseInt(array[4]);
-          long key = (((long) volumeId) << 40) | (offset & 0xFFFFFFFFFFL);
-          return LongStream.range(key, key + sequence);
+          return LongStream.range(0, sequence)
+              .map(i -> (((long) volumeId) << 40) | ((offset + i) & 0xFFFFFFFFFFL));
         });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/umass/storage/StorageTraceReader.java
@@ -50,8 +50,8 @@ public final class StorageTraceReader extends TextTraceReader implements KeyOnly
       long startBlock = Long.parseLong(array[1]);
       int size = Integer.parseInt(array[2]);
       int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
-      long key = (asu << 40) | (startBlock & 0xFFFFFFFFFFL);
-      return LongStream.range(key, key + sequence);
+      return LongStream.range(0, sequence)
+          .map(i -> (asu << 40) | ((startBlock + i) & 0xFFFFFFFFFFL));
     });
   }
 }


### PR DESCRIPTION
EnterpriseTraceReader keys each DiskRead on the byte offset alone, byteOffset/4096, and throws away the DiskNum sitting in column 8. The SNIA Microsoft Enterprise traces are whole-host ETW captures, so a single file carries the I/O against every physical disk on the machine and the byte offset restarts from zero on each one. Two reads at the same offset on different disks then collapse onto one key and the simulator counts the second as a hit, lifting the reported hit rate above what the workload actually saw. I noticed it while reconciling this reader against StorageTraceReader and K5cloudTraceReader, which both already carry their volume identifier through to the key.

Fold the disk number into the high bits of the key (bits 40-63) and leave the per-disk block in the low 40, so distinct disks stop aliasing. The other two readers pack their ASU and volume id the same way for the same reason; keeping the encoding here means the offset and its disk travel together as one block key through LongStream.range rather than asking every policy to disambiguate after the fact.