### PR TITLE
strip the host from https urls in the wikipedia trace reader

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/wikipedia/WikipediaTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/wikipedia/WikipediaTraceReader.java
@@ -103,7 +103,7 @@ public final class WikipediaTraceReader extends TextTraceReader implements KeyOn
 
   /** Returns the path segment of the URL. */
   private static String getPath(String url) {
-    int index = url.indexOf('/', 7);
+    int index = url.indexOf('/', url.indexOf("//") + 2);
     if (index == -1) {
       return url;
     }


### PR DESCRIPTION
getPath finds the path by scanning for the first slash after offset 7, which assumes the scheme is exactly http://. On an https:// URL that offset lands on the second slash of the scheme, so the host is never dropped and the returned path keeps its host/ prefix; the STARTS_WITH_FILTER entries (w/api.php, wiki/Special:Search, wiki/Talk:, ...) then stop matching, because they startsWith bare paths and the host now sits in front. I caught this tracing why a Wikimedia trace replayed far more api.php and Special: traffic than the exclusion list should have let through, and the murmur3 key is taken over the host-prefixed string as well.

The fix starts the scan after the scheme separator so the host is stripped for any scheme length, while http traces parse exactly as before. Keeping it inside getPath means the key hashing and the request filter both see the same clean path rather than each caller having to normalise the URL first. Wikipedia has been https-only since 2015, so traces cut from recent access logs are the common case now, and left as is the reader quietly admits requests it documents as ignored and skews the reported hit rate.