### PR TITLE
saturate oversized object sizes in cdn trace readers

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/adapt_size/AdaptSizeTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/adapt_size/AdaptSizeTraceReader.java
@@ -24,6 +24,7 @@ import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
 import com.google.common.hash.Hashing;
+import com.google.common.primitives.Ints;
 
 /**
  * A reader for the trace files provided by the authors of the AdaptSize algorithm. See
@@ -52,7 +53,7 @@ public final class AdaptSizeTraceReader extends TextTraceReader {
         .map(line -> line.split(" ", 3))
         .map(array -> {
           long key = Long.parseLong(array[1]);
-          int weight = Integer.parseInt(array[2]);
+          int weight = Ints.saturatedCast(Long.parseLong(array[2]));
           long hashKey = Hashing.murmur3_128().newHasher()
               .putLong(key).putInt(weight).hash().asLong();
           return AccessEvent.forKeyAndWeight(hashKey, weight);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/lrb/LrbTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/lrb/LrbTraceReader.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
+import com.google.common.primitives.Ints;
 
 /**
  * A reader for the trace files provided by the authors of the LRB algorithm. See
@@ -47,7 +48,7 @@ public final class LrbTraceReader extends TextTraceReader {
         .map(line -> line.split(" "))
         .map(array -> {
           return AccessEvent.forKeyAndWeight(
-            Long.parseLong(array[1]), Integer.parseInt(array[2]));
+            Long.parseLong(array[1]), Ints.saturatedCast(Long.parseLong(array[2])));
         });
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/tragen/TragenTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/tragen/TragenTraceReader.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import com.github.benmanes.caffeine.cache.simulator.parser.TextTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
+import com.google.common.primitives.Ints;
 
 /**
  * A reader for the trace files provided by the authors of the
@@ -46,6 +47,6 @@ public final class TragenTraceReader extends TextTraceReader {
     return lines()
         .map(line -> line.split(","))
         .map(array -> AccessEvent.forKeyAndWeight(
-            Long.parseLong(array[1]), Integer.parseInt(array[2])));
+            Long.parseLong(array[1]), Ints.saturatedCast(Long.parseLong(array[2]))));
   }
 }


### PR DESCRIPTION
The LRB, AdaptSize and Tragen readers parse the object size column with Integer.parseInt, but each format documents that field as a byte size wider than a signed int: LRB's README calls it uint32, the webcachesim/AdaptSize README calls it a long long int, and Tragen writes unbounded Python ints. A line for an object of 2 GiB or more then makes parseInt throw NumberFormatException, which escapes the stream and aborts the run. I tripped over this replaying a CDN-style LRB trace carrying multi-gigabyte video objects, where the simulation died at LrbTraceReader with "For input string: 3000000000" instead of reporting a hit rate.

Parse the size as a long and saturate it to the int weight with Ints.saturatedCast, the same treatment ObjectStoreTraceReader already gives its byte-size column. Clamping an outsized object to Integer.MAX_VALUE leaves the weighted policies running with a slightly undercounted size, which is far better than discarding the whole trace.