### PR TITLE
read object sizes as unsigned in the oracle and glcache readers

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/glcache/GLCacheTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/glcache/GLCacheTraceReader.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.parser.BinaryTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
+import com.google.common.primitives.Ints;
 
 /**
  * A reader for the trace files provided by the author of GL-Cache. See
@@ -55,9 +56,9 @@ public final class GLCacheTraceReader extends BinaryTraceReader {
      */
     input.skipNBytes(4);
     long key = Long.reverseBytes(input.readLong());
-    int weight = Integer.reverseBytes(input.readInt());
+    long weight = Integer.toUnsignedLong(Integer.reverseBytes(input.readInt()));
     input.skipNBytes(8);
 
-    return AccessEvent.forKeyAndWeight(key, Math.max(weight, 1));
+    return AccessEvent.forKeyAndWeight(key, Math.max(Ints.saturatedCast(weight), 1));
   }
 }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/libcachesim/oracle/OracleGeneralTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/libcachesim/oracle/OracleGeneralTraceReader.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.github.benmanes.caffeine.cache.simulator.parser.BinaryTraceReader;
 import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.Characteristic;
+import com.google.common.primitives.Ints;
 
 /**
  * A reader for the OracleGeneral binary trace format used by
@@ -52,8 +53,8 @@ public final class OracleGeneralTraceReader extends BinaryTraceReader {
 
     input.skipNBytes(4);
     long objId = Long.reverseBytes(input.readLong());
-    int objSize = Integer.reverseBytes(input.readInt());
+    long objSize = Integer.toUnsignedLong(Integer.reverseBytes(input.readInt()));
     input.skipNBytes(8);
-    return AccessEvent.forKeyAndWeight(objId, Math.max(objSize, 1));
+    return AccessEvent.forKeyAndWeight(objId, Math.max(Ints.saturatedCast(objSize), 1));
   }
 }


### PR DESCRIPTION
The GLCache and libCacheSim OracleGeneral readers pull the obj_size column out of the binary record with Integer.reverseBytes(input.readInt()), which keeps it as a signed int. That field is documented as a uint32, so an object in the 2 GiB to 4 GiB range has its top bit set, the signed read goes negative, and Math.max(weight, 1) then quietly floors it to 1. I tripped over this replaying a CDN oracleGeneral trace carrying multi-gigabyte video objects, where the weighted run reported a wildly optimistic hit rate rather than failing, which is what pointed me at the size column.

Read the field with Integer.toUnsignedLong so the whole uint32 survives, then clamp it to the int weight with Ints.saturatedCast, matching what ObjectStoreTraceReader and the CDN text readers already do for their byte-size columns. Keeping the conversion inside readEvent means every weighted policy downstream sees the saturated size instead of a 1, so size accounting and eviction don't get skewed by a single outsized object.