### PR TITLE
include get_lease reads in the cachelib trace reader

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/cachelib/CachelibTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/cachelib/CachelibTraceReader.java
@@ -47,7 +47,7 @@ public final class CachelibTraceReader extends TextTraceReader {
     // header: key, op, size, op_count, key_size
     return lines().skip(1)
         .map(line -> line.split(","))
-        .filter(array -> array[1].equals("GET"))
+        .filter(array -> array[1].equals("GET") || array[1].equals("GET_LEASE"))
         .flatMap(array -> {
           int weight = Integer.parseInt(array[2]) + Integer.parseInt(array[4]);
           var event = AccessEvent.forKeyAndWeight(Long.parseLong(array[0]), weight);


### PR DESCRIPTION
CachelibTraceReader keeps only the rows whose op field equals GET, but cachelib's own KVReplayGenerator treats GET and GET_LEASE alike and maps both to OpType::kGet. A lease-get is still a read of the key; on a miss it additionally acquires a lease, a pattern these production cache services rely on for thundering-herd protection. Replaying the FB HW eval traces I noticed the event count coming up short of the raw line count, and the gap traced back to every GET_LEASE record being filtered out before it reached the stream.

Left as is this quietly drops part of the read workload, so per-key frequency is undercounted and both the hit rate and TinyLFU admission drift on any cachelib trace that uses leases. The fix admits GET_LEASE alongside GET in the same filter, matching cachelib's read-op set, while SET, SET_LEASE and DELETE stay excluded. Keeping the check in the reader lets the downstream policies see the whole read stream without each needing to know the cachelib op vocabulary.