### PR TITLE
include the lun in systor trace keys

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -124,6 +124,7 @@ linearizability
 lirs
 Llirs
 lrb
+lun
 maxcount
 mbean
 MEMSIZE

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/systor/SystorTraceReader.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/snia/systor/SystorTraceReader.java
@@ -52,12 +52,14 @@ public final class SystorTraceReader extends TextTraceReader {
         .filter(array -> !array[1].isEmpty())
         .filter(array -> array[2].equals("R"))
         .flatMap(array -> {
+          long lun = Long.parseLong(array[3]);
           int size = Integer.parseInt(array[5]);
           long startBlock = Long.parseLong(array[4]) / BLOCK_SIZE;
           int sequence = IntMath.divide(size, BLOCK_SIZE, RoundingMode.UP);
           double responseTime = (1000 * Double.parseDouble(array[1])) / sequence;
           return LongStream.range(startBlock, startBlock + sequence)
-              .mapToObj(key -> AccessEvent.forKeyAndPenalties(key, 0, responseTime));
+              .mapToObj(block -> AccessEvent.forKeyAndPenalties(
+                  (lun << 40) | (block & 0xFFFFFFFFFFL), 0, responseTime));
         });
   }
 }


### PR DESCRIPTION
SystorTraceReader keys each block from the byte offset alone, so the LUN column (field 3 of the SYSTOR '17 record) never reaches the key. A trace file interleaves I/O across several LUNs and the offset restarts at zero on each one, so the same offset on two different LUNs collapses onto a single key and the simulator scores independent blocks on separate volumes as cache hits. The inflated hit rate against the per-volume readers is what pointed back here.

Fold the LUN into the high bits of the key and keep the per-LUN block in the low 40 bits. StorageTraceReader (ASU), K5cloudTraceReader (volume id) and EnterpriseTraceReader (disk number) already encode their own volume identifier the same way, so the disambiguation stays where the key is built rather than leaking into every policy.