### PR TITLE
track the camp and gd-wheel weighted size as a long

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/CampPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/CampPolicy.java
@@ -61,7 +61,7 @@ public final class CampPolicy implements Policy {
   private final int bitMask;
 
   private long requestCount;
-  private int size;
+  private long size;
 
   public CampPolicy(Config config) {
     var settings = new CampSettings(config);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GDWheelPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GDWheelPolicy.java
@@ -55,7 +55,7 @@ public final class GDWheelPolicy implements Policy {
   private final int[] clockHand;
   private final double[] cost;
 
-  private int size;
+  private long size;
 
   public GDWheelPolicy(Config config) {
     var settings = new GDWheelSettings(config);
@@ -202,7 +202,7 @@ public final class GDWheelPolicy implements Policy {
 
   @Override
   public void finished() {
-    int expectedSize = data.values().stream().mapToInt(node -> node.weight).sum();
+    long expectedSize = data.values().stream().mapToLong(node -> node.weight).sum();
     checkState(data.size() <= maximumSize, "%s > %s", data.size(), maximumSize);
     checkState(size == expectedSize, "%s != %s", size, expectedSize);
 

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/WeightedSizeOverflowTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/WeightedSizeOverflowTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.policy.greedy_dual;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * The cost-aware policies accumulate the cached weight, which the maximum size allows to exceed the
+ * signed int range. These checks fill a multi-gigabyte cache with byte-sized entries and confirm
+ * the weighted size still bounds the cache so eviction fires.
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ */
+final class WeightedSizeOverflowTest {
+  private static final long MAXIMUM_SIZE = 3_000_000_000L;
+  private static final int WEIGHT = 1_000_000_000;
+
+  @Test
+  void camp() {
+    var policy = new CampPolicy(config());
+    for (int key = 0; key < 4; key++) {
+      policy.record(AccessEvent.forKeyAndWeight(key, WEIGHT));
+    }
+    assertThat(policy.stats().evictionCount()).isGreaterThan(0L);
+  }
+
+  @Test
+  void gdwheel() {
+    var policy = new GDWheelPolicy(config());
+    for (int key = 0; key < 4; key++) {
+      policy.record(AccessEvent.forKeyAndWeight(key, WEIGHT));
+    }
+    assertThat(policy.stats().evictionCount()).isGreaterThan(0L);
+  }
+
+  private static Config config() {
+    var properties = Map.<String, Object>of("maximum-size", MAXIMUM_SIZE);
+    return ConfigFactory.parseMap(properties)
+        .withFallback(ConfigFactory.load().getConfig("caffeine.simulator"));
+  }
+}

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/WeightedSizeOverflowTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/WeightedSizeOverflowTest.java
@@ -18,10 +18,15 @@ package com.github.benmanes.caffeine.cache.simulator.policy.greedy_dual;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
+import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -30,28 +35,26 @@ import com.typesafe.config.ConfigFactory;
  * signed int range. These checks fill a multi-gigabyte cache with byte-sized entries and confirm
  * the weighted size still bounds the cache so eviction fires.
  *
- * @author ben.manes@gmail.com (Ben Manes)
+ * @author sahvx655@gmail.com (Sahana Bogar)
  */
 final class WeightedSizeOverflowTest {
   private static final long MAXIMUM_SIZE = 3_000_000_000L;
   private static final int WEIGHT = 1_000_000_000;
 
-  @Test
-  void camp() {
-    var policy = new CampPolicy(config());
+  @ParameterizedTest
+  @MethodSource("policies")
+  void overflow(Function<Config, Policy> factory) {
+    var policy = factory.apply(config());
     for (int key = 0; key < 4; key++) {
       policy.record(AccessEvent.forKeyAndWeight(key, WEIGHT));
     }
     assertThat(policy.stats().evictionCount()).isGreaterThan(0L);
   }
 
-  @Test
-  void gdwheel() {
-    var policy = new GDWheelPolicy(config());
-    for (int key = 0; key < 4; key++) {
-      policy.record(AccessEvent.forKeyAndWeight(key, WEIGHT));
-    }
-    assertThat(policy.stats().evictionCount()).isGreaterThan(0L);
+  static Stream<Named<Function<Config, Policy>>> policies() {
+    return Stream.of(
+        Named.of("camp", CampPolicy::new),
+        Named.of("gdwheel", GDWheelPolicy::new));
   }
 
   private static Config config() {


### PR DESCRIPTION
Running the cost-aware policies over a byte-weighted trace with a maximum size above ~2 GiB, GD-Wheel quietly retained more than the configured limit and CAMP aborted in `finished()` with a `size != weightedSize` mismatch. Both track the resident weight in an `int size` field while `maximumSize` is a `long` and the per-entry weight comes straight off the trace, so once the cached weight passes `Integer.MAX_VALUE` the accumulator wraps negative. The `size > maximumSize` guards then stop firing, eviction never runs, and the cache grows past its bound; GD-Wheel reports an inflated hit rate and CAMP only catches it at shutdown when its weighted-size assertion trips.

Widen `size` to `long` in both, which is what the sibling weighted policies (Gdsf, Sieve, Linked, S3Fifo) already do. GD-Wheel summed the entry weights with `mapToInt` in `finished()`, so the consistency check overflowed in step with the field and hid the divergence; that sum is now `mapToLong` to match `GdsfPolicy`. Keeping the width right at the accumulator corrects every add and comparison without touching the eviction logic.
