### PR TITLE
warm up the clockprosimple hot set

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimplePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimplePolicy.java
@@ -174,10 +174,20 @@ public final class ClockProSimplePolicy implements KeyOnlyPolicy {
     policyStats.recordMiss();
     epoch++;
     var node = new Node(key, epoch);
-    node.status = Status.COLD;
-    node.link(headCold);
+    // While the clock is not full, entries accessed for the first time are given HOT status until
+    // the resident set reaches maxSize - minColdSize; only after that are they inserted as cold in
+    // their test period. Without this warm-up the hot list never fills, so the policy degenerates
+    // to Clock and discards the entries it is meant to retain.
+    if ((sizeHot + sizeCold) < (maxSize - minColdSize)) {
+      node.status = Status.HOT;
+      node.link(headHot);
+      sizeHot++;
+    } else {
+      node.status = Status.COLD;
+      node.link(headCold);
+      sizeCold++;
+    }
     data.put(key, node);
-    sizeCold++;
     evict();
   }
 

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimpleWarmupTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimpleWarmupTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.policy.irr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * ClockProSimple is meant to track ClockPro. On a looping workload larger than the cache, ClockPro
+ * warms up a hot set that survives the scan and scores hits; without that warm-up the simplified
+ * port inserts every first access as cold, degrades to Clock, and never hits. This pins the
+ * simplified port near its reference so the warm-up cannot regress.
+ *
+ * @author sahvx655@gmail.com (Sahana Bogar)
+ */
+final class ClockProSimpleWarmupTest {
+  private static final int MAXIMUM_SIZE = 100;
+  private static final int ITEMS = 250;
+  private static final int LOOPS = 5;
+
+  @Test
+  void loopMatchesClockPro() {
+    var reference = new ClockProPolicy(config());
+    var simple = new ClockProSimplePolicy(config());
+    for (int loop = 0; loop < LOOPS; loop++) {
+      for (long key = 0; key < ITEMS; key++) {
+        reference.record(key);
+        simple.record(key);
+      }
+    }
+    assertThat(simple.stats().hitCount()).isGreaterThan(0L);
+    assertThat(simple.stats().hitCount()).isAtLeast(reference.stats().hitCount() / 2);
+  }
+
+  private static Config config() {
+    var properties = Map.<String, Object>of("maximum-size", MAXIMUM_SIZE);
+    return ConfigFactory.parseMap(properties)
+        .withFallback(ConfigFactory.load().getConfig("caffeine.simulator"));
+  }
+}


### PR DESCRIPTION
Running the bundled LIRS traces past the policies, irr.ClockProSimple reports a 0% hit rate on loop at size 500 while irr.ClockPro and irr.ClockProPlus both score 48.86% on the same input, tying plain linked.Lru at zero. The fault is in onMiss: every first-access entry is linked into the cold list, so the hot list never fills. Since inTestPeriod returns true whenever sizeHot is zero, no cold entry is ever held long enough to be promoted, and the policy collapses to Clock behaviour over the whole key space and discards the working set it is meant to keep.

ClockPro and ClockProPlus seed the hot set during warm-up, giving newly accessed entries hot status until the resident size reaches maxSize minus minColdSize and only then inserting them cold in their test period. onMiss here was missing that branch even though the class doc states it works exactly like ClockPro. Adding the same warm-up restores loop to 48.86%, tracks ClockPro on multi1/multi3/cs within the small gap left by the consecutive-duplicate dedup the simple variant omits, and keeps the decision in onMiss beside the other first-touch handling where the sibling policies make it. The added test drives a loop larger than the cache and fails with zero hits on the current code.
