### PR TITLE
skip consecutive duplicate accesses in lirs

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsPolicy.java
@@ -77,6 +77,12 @@ public final class LirsPolicy implements KeyOnlyPolicy {
   int sizeHot;
   int residentSize;
 
+  // Skips consecutive duplicate accesses to a block. The stack pruning and LIR/HIR role swap are
+  // not idempotent, so counting "key, key" as two events diverges from Song Jiang's reference,
+  // which collapses such correlated references to a single access.
+  long lastKey = Long.MIN_VALUE;
+  boolean hasLastKey;
+
   public LirsPolicy(Config config) {
     var settings = new LirsSettings(config);
     this.maximumSize = Math.toIntExact(settings.maximumSize());
@@ -92,6 +98,12 @@ public final class LirsPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
+    if (hasLastKey && (key == lastKey)) {
+      return;
+    }
+    lastKey = key;
+    hasLastKey = true;
+
     @Var @Nullable Node node = data.get(key);
     policyStats.recordOperation();
     if (node == null) {

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsCorrelatedAccessTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsCorrelatedAccessTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.policy.irr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * LIRS treats a rapid re-access to the same block (a "correlated reference") as a single event, the
+ * convention its siblings Lirs2 and ClockPro already follow. These checks confirm a consecutive
+ * duplicate is collapsed while a genuine non-consecutive reuse is still counted.
+ *
+ * @author sahvx655@gmail.com (Sahana Bogar)
+ */
+final class LirsCorrelatedAccessTest {
+
+  @Test
+  void skipsConsecutiveDuplicate() {
+    var policy = new LirsPolicy(config());
+    policy.record(1);
+    policy.record(1);
+    assertThat(policy.stats().hitCount()).isEqualTo(0);
+  }
+
+  @Test
+  void countsNonConsecutiveReuse() {
+    var policy = new LirsPolicy(config());
+    policy.record(1);
+    policy.record(2);
+    policy.record(1);
+    assertThat(policy.stats().hitCount()).isEqualTo(1);
+  }
+
+  private static Config config() {
+    var properties = Map.<String, Object>of("maximum-size", 10);
+    return ConfigFactory.parseMap(properties)
+        .withFallback(ConfigFactory.load().getConfig("caffeine.simulator"));
+  }
+}


### PR DESCRIPTION
The Lirs2 and ClockPro policies both collapse a rapid re-access to the same block (a correlated reference) to a single event at the top of record(), but irr.Lirs never picked up that guard. I noticed it while reconciling the irr family against Song Jiang's reference: Lirs2Policy's own comment points back at "the original LIRS conventions, which collapse such pairs to a single access", yet LirsPolicy counts "key, key" as a miss followed by a hit. The stack pruning and the LIR/HIR role swap are not idempotent, so a repeated key reorders stack S and can demote a different LIR block than a single access would, skewing the recency ordering and the reported hit rate on any trace with back-to-back duplicates.

Add the same lastKey guard the siblings use so a consecutive duplicate is ignored before any stack mutation. Keeping it in record() matches Lirs2 and ClockPro and the reference, where the dedup sits at the top of run_lirs; a non-consecutive reuse still counts as a genuine hit. The test covers both cases: "1, 1" records no hit, "1, 2, 1" records one.