### PR TITLE
remove the doubled prefix from sampled policy names

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sampled/SampledPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sampled/SampledPolicy.java
@@ -69,7 +69,7 @@ public final class SampledPolicy implements KeyOnlyPolicy {
   long tick;
 
   public SampledPolicy(Admission admission, EvictionPolicy policy, Config config) {
-    this.policyStats = new PolicyStats(admission.format("sampled." + policy.label()));
+    this.policyStats = new PolicyStats(admission.format(policy.label()));
     this.admitter = admission.from(config, policyStats);
 
     var settings = new SampledSettings(config);


### PR DESCRIPTION
Running the simulator over the bundled traces, every sampled policy comes back in the results table as `sampled.sampled.Lru`, `sampled.sampled.Mru` and so on, with a doubled prefix. `SampledPolicy.EvictionPolicy.label()` already returns `sampled.Lru`, but the constructor prepends another `sampled.` on top of it, so the sampled family is the only one whose reported name disagrees with the name it is registered and configured under. `LinkedPolicy` and `FrequentlyUsedPolicy` pass `policy.label()` straight through to `PolicyStats`.

Drop the redundant prefix so the reported name matches the registered name. That label is what the table and CSV report sort and join on, so a `sampled.Lru` row currently cannot be matched back to the `sampled.Lru` requested in the config, and any tooling correlating results to the configured policy quietly misses the sampled entries. Hit rates and every other figure are unchanged; only the label differs.