### PR TITLE
fix the climber sketch reset to match the periodic down-sample

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/admission/countmin4/ClimberResetCountMin4.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/admission/countmin4/ClimberResetCountMin4.java
@@ -95,7 +95,7 @@ public final class ClimberResetCountMin4 extends CountMin4 {
       count += Long.bitCount(table[i] & ONE_MASK);
       table[i] = (table[i] >>> 1) & RESET_MASK;
     }
-    additions = (additions >>> 1) - (count >>> 2);
+    additions = (additions - (count >>> 2)) >>> 1;
     doorkeeper.clear();
   }
 

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/admission/countmin4/ClimberResetCountMin4Test.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/admission/countmin4/ClimberResetCountMin4Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.admission.countmin4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * The climber and periodic resets share the same down-sampling docstring and the production
+ * FrequencySketch reset: halve every counter, then reduce the sample by the truncation lost to the
+ * odd counters. Given identical table state they must reduce the sample identically.
+ *
+ * @author sahvx655@gmail.com (Sahana Bogar)
+ */
+final class ClimberResetCountMin4Test {
+  private static final int MAXIMUM_SIZE = 512;
+
+  @Test
+  void reset_matchesPeriodicDownSample() {
+    var climber = new ClimberResetCountMin4(config());
+    var periodic = new PeriodicResetCountMin4(config());
+
+    // An identical table where every counter is odd maximises the truncation correction.
+    long[] table = new long[climber.table.length];
+    Arrays.fill(table, ClimberResetCountMin4.ONE_MASK);
+    climber.table = table.clone();
+    periodic.table = table.clone();
+
+    climber.step = 1;
+    climber.additions = climber.period - 1;
+    periodic.additions = periodic.period - 1;
+
+    climber.tryReset(/* added= */ true);
+    periodic.tryReset(/* added= */ true);
+
+    assertThat(climber.additions).isEqualTo(periodic.additions);
+  }
+
+  private static Config config() {
+    var properties = Map.<String, Object>of("maximum-size", MAXIMUM_SIZE);
+    return ConfigFactory.parseMap(properties)
+        .withFallback(ConfigFactory.load().getConfig("caffeine.simulator"));
+  }
+}


### PR DESCRIPTION
ClimberResetCountMin4.tryReset down-samples the running sample with `additions = (additions >>> 1) - (count >>> 2)`, halving the sample first and only then subtracting the odd-counter truncation correction. The other two implementations of the same reset disagree: PeriodicResetCountMin4 and the production FrequencySketch.reset() both compute `(additions - (count >>> 2)) >>> 1`, and all three carry the identical docstring about reducing the sample by the number of counters with an odd value. Halving first takes count/4 off the already-halved sample instead of count/8, so twice the intended correction is removed on every reset.

The result is that `additions` lands too low after each reset, so the climber takes longer to climb back to `period` and ages the sketch less often than the periodic variant it is meant to mirror, which skews the simulated hit rate for the `climber` and `indicator` reset modes (indicator wraps the climber). The correction belongs before the halving, since the truncation it compensates for is produced by that halving step, so reordering to `(additions - (count >>> 2)) >>> 1` brings the climber back in line with the periodic reset and the production sketch. The added test pins the climber post-reset sample to the periodic reset for identical table state.