### PR TITLE
count the eviction into dclock's refault distance

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/DClockPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/DClockPolicy.java
@@ -205,8 +205,10 @@ public final class DClockPolicy implements KeyOnlyPolicy {
       Node victim = requireNonNull(headInactive.prev);
       policyStats.recordEviction();
 
-      victim.nonResidentAge = currentNonResidentAge();
+      // Advance the age before stamping so the shadow's refault distance counts this eviction,
+      // matching workingset_age_nonresident running ahead of the read in the kernel reference.
       evictions++;
+      victim.nonResidentAge = currentNonResidentAge();
       inactiveSize--;
       victim.remove();
       victim.status = Status.NON_RESIDENT;

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/DClockRefaultDistanceTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/DClockRefaultDistanceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.policy.irr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.benmanes.caffeine.cache.simulator.policy.irr.DClockPolicy.DClockSettings;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * DClock stamps an evicted shadow with the refault distance measured from the nonresident age. The
+ * cited reference (linux/mm/workingset.c) advances that age via {@code workingset_age_nonresident}
+ * before reading it to stamp the page, so the stamp counts the eviction itself; a page that refaults
+ * at exactly the active size is then optimistically activated. This pins that boundary case: the
+ * hot key survives a following scan only if the refault promoted it to the active list.
+ *
+ * @author sahvx655@gmail.com (Sahana Bogar)
+ */
+final class DClockRefaultDistanceTest {
+
+  @Test
+  void boundaryRefaultIsActivated() {
+    var policy = new DClockPolicy(new DClockSettings(config()), /* percentActive= */ 0.5);
+
+    // A B C prime the two-entry cache and evict A to the shadow list at refault distance 0. The
+    // re-access of A refaults at exactly the (empty) active size, so it must be promoted. D E F G
+    // scan the inactive list; A survives only if it was activated, and the final A then hits.
+    for (long key : new long[] {0, 1, 2, 0, 3, 4, 5, 6, 0}) {
+      policy.record(key);
+    }
+    policy.finished();
+
+    assertThat(policy.stats().hitCount()).isEqualTo(1);
+  }
+
+  private static Config config() {
+    var properties = Map.<String, Object>of("maximum-size", 2);
+    return ConfigFactory.parseMap(properties)
+        .withFallback(ConfigFactory.load().getConfig("caffeine.simulator"));
+  }
+}


### PR DESCRIPTION
DClock stamps each evicted shadow with the nonresident age (evictions + activations) and later reads it back as the refault distance that gates optimistic activation. The stamp is taken before the eviction is counted, so every recorded distance sits one slot above the cited linux/mm/workingset.c reference, which advances the age through workingset_age_nonresident ahead of the read that stamps the page. A shadow that refaults at exactly the active-list size is then demoted to inactive at the boundary the kernel would promote on.

Counting the eviction before the stamp lines the distance up with the reference and restores that boundary promotion. It is not purely cosmetic: the page that should have been pinned in the active list stays inactive, is caught by the next scan, and misses on its next reuse, so DClock's hit rate drifts under the algorithm it models. The regression drives a two-entry cache where the hot key only survives a following scan if its boundary refault activated it.
