### PR TITLE
size the simulate chart y-axis to the plotted metric

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/csv/PlotCsv.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/csv/PlotCsv.java
@@ -116,8 +116,8 @@ public record PlotCsv(Path inputFile, Path outputFile, String metric,
   }
 
   private static Range calculateRange(CategoryPlot plot) {
-    @Var double upperBound = 0;
-    @Var double lowerBound = 100;
+    @Var double upperBound = Double.NEGATIVE_INFINITY;
+    @Var double lowerBound = Double.POSITIVE_INFINITY;
     checkState(plot.getDataset().getRowCount() > 0, "No data points to plot");
     for (int series = 0; series < plot.getDataset().getRowCount(); series++) {
       for (int item = 0; item < plot.getDataset().getColumnCount(); item++) {
@@ -129,7 +129,7 @@ public record PlotCsv(Path inputFile, Path outputFile, String metric,
       }
     }
     double margin = 0.1 * (upperBound - lowerBound);
-    return new Range(Math.max(0, lowerBound - margin), Math.min(100, upperBound + margin));
+    return new Range(lowerBound - margin, upperBound + margin);
   }
 
   private void applyTheme(JFreeChart chart) {


### PR DESCRIPTION
Simulate exposes --metric to chart any column PolicyStats records, but PlotCsv.calculateRange seeds its bounds at 0 and 100 and clamps the returned range to [0, 100], so it quietly assumes the series is a percentage. Charting a count or latency metric such as --metric=Requests or --metric='Average Penalty' pushes every point far above 100, so the whole series is clipped off the top and the plot comes out blank. A percentage that can go negative, --metric=Adaption, is clipped at the bottom the same way.

Track the real minimum and maximum of the plotted values and pad by ten percent on each side, without the [0, 100] clamp. Hit-rate charts are unaffected since their values already sit inside that window. The bound belongs in the plotter because that is the only stage that still sees the actual series values; the metric type is gone once the combined csv has been written.