### PR TITLE
stroke every policy line in the simulate chart

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/csv/PlotCsv.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/csv/PlotCsv.java
@@ -110,7 +110,7 @@ public record PlotCsv(Path inputFile, Path outputFile, String metric,
     plot.getRangeAxis().setAutoRange(false);
     plot.getRangeAxis().setRange(calculateRange(plot));
 
-    for (int i = 0; i < plot.getCategories().size(); i++) {
+    for (int i = 0; i < plot.getDataset().getRowCount(); i++) {
       plot.getRenderer().setSeriesStroke(i, new BasicStroke(3.0f));
     }
   }


### PR DESCRIPTION
Comparing a handful of policies over a couple of maximum sizes, the generated chart came back with only the first two lines drawn thick and the rest left hairline-thin. configurePlot widens each line to 3px but bounds the loop by plot.getCategories().size(), which is the count of maximum-size columns along the x-axis, whereas setSeriesStroke indexes the series that data() builds from the policy names. Once a chart holds more policies than distinct sizes the trailing policy lines never receive the stroke and fall back to the theme default, so the plot reads as if some policies were emphasised over others.

Bound the loop by plot.getDataset().getRowCount() instead, which is the series count. The calculateRange helper just below already walks getRowCount() for that same axis, so pinning the stroke loop to the row count keeps the two consistent and every policy line renders at the intended width.