### PR TITLE
flush the console report writer instead of closing System.out

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporter.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.US;
 import static java.util.Objects.requireNonNull;
 
+import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
@@ -93,7 +94,14 @@ public abstract class TextReporter implements Reporter {
   private Writer makeWriter() throws IOException {
     String output = settings.report().output();
     if (output.equalsIgnoreCase("console")) {
-      return new PrintWriter(System.out, /* autoFlush= */ true, UTF_8);
+      // print() closes the writer, but System.out belongs to the process, not the reporter.
+      // Flush instead of closing so the caller's later output is not dropped onto a dead stream.
+      var console = new PrintWriter(System.out, /* autoFlush= */ true, UTF_8);
+      return new FilterWriter(console) {
+        @Override public void close() throws IOException {
+          flush();
+        }
+      };
     }
     var path = Path.of(output);
     var parent = path.getParent();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporter.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporter.java
@@ -94,11 +94,10 @@ public abstract class TextReporter implements Reporter {
   private Writer makeWriter() throws IOException {
     String output = settings.report().output();
     if (output.equalsIgnoreCase("console")) {
-      // print() closes the writer, but System.out belongs to the process, not the reporter.
-      // Flush instead of closing so the caller's later output is not dropped onto a dead stream.
       var console = new PrintWriter(System.out, /* autoFlush= */ true, UTF_8);
       return new FilterWriter(console) {
         @Override public void close() throws IOException {
+          console.println();
           flush();
         }
       };

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporterTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/report/TextReporterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.report;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.benmanes.caffeine.cache.simulator.policy.PolicyStats;
+import com.github.benmanes.caffeine.cache.simulator.report.table.TableReporter;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * The console reporter writes through System.out, which the process owns. Printing a report must
+ * not close it, or the caller's later output (e.g. the run's elapsed time) is silently dropped.
+ *
+ * @author sahvx655@gmail.com (Sahana Bogar)
+ */
+final class TextReporterTest {
+
+  @Test
+  @SuppressWarnings({"PMD.CloseResource", "SystemOut"})
+  void print_console_keepsSystemOutOpen() {
+    var original = System.out;
+    var stats = new PolicyStats("test");
+    stats.recordHit();
+    stats.recordMiss();
+    var config = ConfigFactory.load().getConfig("caffeine.simulator");
+    try (var console = new CloseAwarePrintStream(OutputStream.nullOutputStream())) {
+      System.setOut(console);
+      new TableReporter(config, Set.of()).print(List.of(stats));
+      assertThat(console.closed).isFalse();
+    } finally {
+      System.setOut(original);
+    }
+  }
+
+  private static final class CloseAwarePrintStream extends PrintStream {
+    boolean closed;
+
+    CloseAwarePrintStream(OutputStream out) {
+      super(out, /* autoFlush= */ true, UTF_8);
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+      super.close();
+    }
+  }
+}


### PR DESCRIPTION
The console report path in `TextReporter.makeWriter` hands `print()` a `PrintWriter` wrapping `System.out`, and `print()` closes that writer in its try-with-resources. Closing the writer closes `System.out` with it, so once a report has been rendered the process has no stdout left: the "Executed in ..." line that `Simulator.main` prints next lands on a closed stream and is silently swallowed, with `System.out.checkError()` flipping to true right after the report. Every default console run hits this, and anything that later writes to stdout would disappear the same way.

The reporter does not own `System.out`, so the console writer now flushes on close instead of propagating the close, leaving the stream open. Keeping that behaviour in `makeWriter` means the file-output branch still closes its writer as before and `print()` stays a generic try-with-resources over any `Writer`. Added a regression test that swaps in a close-tracking stdout and checks the reporter leaves it open.
