### PR TITLE
gate the minisim window resize on a full cache

### DIFF
--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/sim/MiniSimClimber.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/sim/MiniSimClimber.java
@@ -89,7 +89,7 @@ public final class MiniSimClimber implements HillClimber {
   @Override
   public Adaptation adapt(double windowSize,
       double probationSize, double protectedSize, boolean isFull) {
-    if (sample <= period) {
+    if (!isFull || (sample <= period)) {
       return Adaptation.hold();
     }
 

--- a/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/MiniSimUnfilledResizeTest.java
+++ b/simulator/src/test/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/MiniSimUnfilledResizeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.benmanes.caffeine.cache.simulator.policy.sketch.climbing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.benmanes.caffeine.cache.simulator.policy.AccessEvent;
+import com.github.benmanes.caffeine.cache.simulator.policy.Policy;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * The minisim climber adapts the admission window at its period boundary regardless of whether the
+ * cache is full. A trace whose working set stays below the window capacity keeps the window
+ * under-filled, so the period-boundary resize walks past the resident window nodes.
+ *
+ * @author sahvx655@gmail.com (Sahana Bogar)
+ */
+final class MiniSimUnfilledResizeTest {
+
+  @Test
+  void unfilledWindowResize() {
+    var policy = policy();
+    // Three keys against a 1,000-entry cache leaves the ~1% window far below its capacity; replay
+    // past the (shortened) minisim period so the boundary adaptation fires while under-filled.
+    for (int i = 0; i < 200; i++) {
+      policy.record(AccessEvent.forKey(i % 3));
+    }
+    assertThat(policy.stats().requestCount()).isEqualTo(200L);
+  }
+
+  private static Policy policy() {
+    var config = ConfigFactory.parseString("""
+        maximum-size = 1000
+        hill-climber-window-tiny-lfu {
+          strategy = [ minisim ]
+          percent-main = [ 0.99 ]
+          minisim.period = 100
+        }
+        """).withFallback(ConfigFactory.load().getConfig("caffeine.simulator"));
+    return HillClimberWindowTinyLfuPolicy.policies(config).iterator().next();
+  }
+}


### PR DESCRIPTION
The minisim strategy for sketch.HillClimberWindowTinyLfu resizes the admission window at every period boundary without checking whether the cache has filled, unlike its siblings: AbstractClimber.adapt holds while the cache is under capacity and IndicatorClimber only accumulates its sample once full. A trace whose working set stays below the window capacity therefore keeps the window under-filled, yet at the boundary decreaseWindow still sizes its move count from the window capacity (quota = min(amount, maxWindow)) rather than the resident node count. The move loop walks off the window list onto the headWindow sentinel and the run dies with a NullPointerException in Node.appendToHead, with windowSize going negative and tripping the checkState right after; I traced it back from that stack after replaying a small-working-set trace.

The fix holds the adaptation while the cache is not full, mirroring AbstractClimber, so a resize only fires once window occupancy equals the window capacity and the move count can no longer exceed the resident nodes. Keeping the guard in the climber leaves the policy's resize maths untouched and puts minisim in the same full-cache-only regime the other strategies already rely on. Left unfixed this aborts the whole simulation for any minisim run over a trace with few distinct keys, so the added test replays three keys past a shortened period and reproduces the crash without the change.
