### PR TITLE
handle an expired prior in postProcess read and update actions

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -901,7 +901,12 @@ public class CacheProxy<K, V> implements Cache<K, V> {
         publishExpiredPrior(entry.getKey(), expiredValue);
         return expirable;
       case READ: {
-        setAccessExpireTime(entry.getKey(), requireNonNull(expirable), 0L);
+        if (expirable == null) {
+          // the read entry expired lazily during processing, so publish its expiration and drop it
+          publishExpiredPrior(entry.getKey(), expiredValue);
+          return null;
+        }
+        setAccessExpireTime(entry.getKey(), expirable, 0L);
         return expirable;
       }
       case CREATED:
@@ -922,9 +927,22 @@ public class CacheProxy<K, V> implements Cache<K, V> {
         return new Expirable<>(value, expireTimeMillis);
       }
       case UPDATED: {
+        if (expirable == null) {
+          // the prior expired lazily during processing, so the write is a creation, not an update
+          publishToCacheWriter(writer::write, () -> entry);
+          V created = copyOf(requireNonNull(entry.getValue(), "Expected a new value but was null"));
+          publishExpiredPrior(entry.getKey(), expiredValue);
+          long expireTimeMillis = getWriteExpireTimeMillis(/* created= */ true);
+          if (expireTimeMillis == 0) {
+            dispatcher.publishExpired(this, entry.getKey(), created);
+            return null;
+          }
+          statistics.recordPuts(1L);
+          dispatcher.publishCreated(this, entry.getKey(), created);
+          return new Expirable<>(created, expireTimeMillis);
+        }
         publishToCacheWriter(writer::write, () -> entry);
         statistics.recordPuts(1L);
-        requireNonNull(expirable, "Expected a previous value but was null");
         V value = copyOf(requireNonNull(entry.getValue(), "Expected a new value but was null"));
         dispatcher.publishUpdated(this, entry.getKey(), expirable.get(), value);
         @Var long expireTimeMillis = getWriteExpireTimeMillis(/* created= */ false);

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/CacheProxyTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/CacheProxyTest.java
@@ -772,6 +772,61 @@ final class CacheProxyTest {
   }
 
   @Test
+  void postProcess_read_expiredPrior_publishesExpiredForPrior() {
+    try (var fixture = jcacheFixture(Mockito.mock(), Mockito.mock(), Mockito.mock())) {
+      var expired = new Expirable<>(VALUE_1, fixture.currentTime().toMillis() - 1);
+      EntryProcessorEntry<Integer, Integer> entry = Mockito.mock();
+      when(entry.getAction()).thenReturn(Action.READ);
+      when(entry.getKey()).thenReturn(KEY_1);
+
+      var stats = JCacheFixture.getStatistics(fixture.jcache());
+      long evictionsBefore = stats.getCacheEvictions();
+      assertThat(fixture.jcache().postProcess(expired, entry, 0L)).isNull();
+      assertThat(stats.getCacheEvictions()).isEqualTo(evictionsBefore + 1);
+    }
+  }
+
+  @Test
+  void postProcess_updated_expiredPrior_publishesExpiredForPrior() {
+    try (var fixture = jcacheFixture(Mockito.mock(), Mockito.mock(), Mockito.mock())) {
+      var expired = new Expirable<>(VALUE_1, fixture.currentTime().toMillis() - 1);
+      EntryProcessorEntry<Integer, Integer> entry = Mockito.mock();
+      when(entry.getAction()).thenReturn(Action.UPDATED);
+      when(entry.getKey()).thenReturn(KEY_1);
+      when(entry.getValue()).thenReturn(VALUE_2);
+
+      var stats = JCacheFixture.getStatistics(fixture.jcache());
+      long evictionsBefore = stats.getCacheEvictions();
+      long putsBefore = stats.getCachePuts();
+      var result = fixture.jcache().postProcess(expired, entry, 0L);
+      assertThat(result).isNotNull();
+      assertThat(result.get()).isEqualTo(VALUE_2);
+      assertThat(stats.getCacheEvictions()).isEqualTo(evictionsBefore + 1);
+      assertThat(stats.getCachePuts()).isEqualTo(putsBefore + 1);
+    }
+  }
+
+  @Test
+  void postProcess_updated_expiredPriorZeroCreation_notAdded() throws IOException {
+    try (CloseableExpiryPolicy expiry = Mockito.mock();
+        var fixture = jcacheFixture(Mockito.mock(), Mockito.mock(), expiry)) {
+      when(expiry.getExpiryForCreation()).thenReturn(Duration.ZERO);
+      var expired = new Expirable<>(VALUE_1, fixture.currentTime().toMillis() - 1);
+      EntryProcessorEntry<Integer, Integer> entry = Mockito.mock();
+      when(entry.getAction()).thenReturn(Action.UPDATED);
+      when(entry.getKey()).thenReturn(KEY_1);
+      when(entry.getValue()).thenReturn(VALUE_2);
+
+      var stats = JCacheFixture.getStatistics(fixture.jcache());
+      long evictionsBefore = stats.getCacheEvictions();
+      long putsBefore = stats.getCachePuts();
+      assertThat(fixture.jcache().postProcess(expired, entry, 0L)).isNull();
+      assertThat(stats.getCacheEvictions()).isEqualTo(evictionsBefore + 1);
+      assertThat(stats.getCachePuts()).isEqualTo(putsBefore);
+    }
+  }
+
+  @Test
   void setAccessExpireTime_eternal() throws IOException {
     try (CloseableExpiryPolicy expiry = Mockito.mock();
         var fixture = jcacheFixture(Mockito.mock(), Mockito.mock(), expiry)) {


### PR DESCRIPTION
Cache.invoke reads the entry, runs the user's EntryProcessor, then passes the result to postProcess, which re-reads the clock and nulls its local expirable when the prior entry has lapsed since that initial read. The NONE, CREATED/LOADED and DELETED branches all cope with that null, but READ and UPDATED assert requireNonNull(expirable), so an entry that expires lazily mid-processing throws NullPointerException back through invoke as an EntryProcessorException. On the UPDATED path recordPuts and CacheWriter.write both run before the assertion, so a write-through fires and the put statistic ticks up on an operation that then fails and stores nothing, leaving the backing store and the cache out of step.

Give both branches the handling their siblings already have: publish the prior's deferred expiration and, for an update, finish it as a creation since an update whose prior has gone is really a create, honouring a zero creation expiry the way the CREATED branch does. Keeping it in postProcess means the per-key compute still holds the entry, so the expiry decision stays atomic with the write. The existing postProcess tests drive the NONE, CREATED and DELETED expired-prior cases directly, so I added the read and update counterparts, which throw before this change and pass after.
