### PR TITLE
record put and remove time only on an actual mutation

### DIFF
--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -332,10 +332,8 @@ public class CacheProxy<K, V> implements Cache<K, V> {
     var result = putNoCopyOrAwait(key, value, /* publishToWriter= */ true);
     dispatcher.awaitSynchronous();
 
-    if (statsEnabled) {
-      if (result.written) {
-        statistics.recordPuts(1);
-      }
+    if (statsEnabled && result.written) {
+      statistics.recordPuts(1);
       statistics.recordPutTime(ticker.read() - start);
     }
   }
@@ -355,12 +353,12 @@ public class CacheProxy<K, V> implements Cache<K, V> {
       } else {
         statistics.recordHits(1L);
       }
+      long duration = ticker.read() - start;
       if (result.written) {
         statistics.recordPuts(1);
+        statistics.recordPutTime(duration);
       }
-      long duration = ticker.read() - start;
       statistics.recordGetTime(duration);
-      statistics.recordPutTime(duration);
     }
     return (result.oldValue == null) ? null : copyOf(result.oldValue);
   }
@@ -453,7 +451,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
       dispatcher.awaitSynchronous();
     }
 
-    if (statsEnabled) {
+    if (statsEnabled && (puts > 0)) {
       statistics.recordPuts(puts);
       statistics.recordPutTime(ticker.read() - start);
     }
@@ -476,10 +474,10 @@ public class CacheProxy<K, V> implements Cache<K, V> {
       if (added) {
         statistics.recordPuts(1L);
         statistics.recordMisses(1L);
+        statistics.recordPutTime(ticker.read() - start);
       } else {
         statistics.recordHits(1L);
       }
-      statistics.recordPutTime(ticker.read() - start);
     }
     return added;
   }
@@ -536,11 +534,11 @@ public class CacheProxy<K, V> implements Cache<K, V> {
     V value = removeNoCopyOrAwait(key);
     dispatcher.awaitSynchronous();
 
-    if (statsEnabled) {
-      statistics.recordRemoveTime(ticker.read() - start);
-    }
     if (value != null) {
       statistics.recordRemovals(1L);
+      if (statsEnabled) {
+        statistics.recordRemoveTime(ticker.read() - start);
+      }
       return true;
     }
     return false;
@@ -606,12 +604,12 @@ public class CacheProxy<K, V> implements Cache<K, V> {
       if (removed[0]) {
         statistics.recordRemovals(1L);
         statistics.recordHits(1L);
+        statistics.recordRemoveTime(ticker.read() - start);
       } else if (found[0]) {
         statistics.recordHits(1L);
       } else {
         statistics.recordMisses(1L);
       }
-      statistics.recordRemoveTime(ticker.read() - start);
     }
     return removed[0];
   }
@@ -629,14 +627,14 @@ public class CacheProxy<K, V> implements Cache<K, V> {
 
     V copy = (value == null) ? null : copyOf(value);
     if (statsEnabled) {
+      long duration = ticker.read() - start;
       if (copy == null) {
         statistics.recordMisses(1L);
       } else {
         statistics.recordHits(1L);
         statistics.recordRemovals(1L);
+        statistics.recordRemoveTime(duration);
       }
-      long duration = ticker.read() - start;
-      statistics.recordRemoveTime(duration);
       statistics.recordGetTime(duration);
     }
     return copy;
@@ -684,12 +682,14 @@ public class CacheProxy<K, V> implements Cache<K, V> {
     dispatcher.awaitSynchronous();
 
     if (statsEnabled) {
-      statistics.recordPuts(replaced[0] ? 1L : 0L);
       statistics.recordMisses(found[0] ? 0L : 1L);
       statistics.recordHits(found[0] ? 1L : 0L);
       long duration = ticker.read() - start;
+      if (replaced[0]) {
+        statistics.recordPuts(1L);
+        statistics.recordPutTime(duration);
+      }
       statistics.recordGetTime(duration);
-      statistics.recordPutTime(duration);
     }
 
     return replaced[0];
@@ -732,15 +732,15 @@ public class CacheProxy<K, V> implements Cache<K, V> {
 
     V copy = (oldValue == null) ? null : copyOf(oldValue);
     if (statsEnabled) {
+      long duration = ticker.read() - start;
       if (copy == null) {
         statistics.recordMisses(1L);
       } else {
         statistics.recordHits(1L);
         statistics.recordPuts(1L);
+        statistics.recordPutTime(duration);
       }
-      long duration = ticker.read() - start;
       statistics.recordGetTime(duration);
-      statistics.recordPutTime(duration);
     }
     return copy;
   }
@@ -808,7 +808,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
     }
     dispatcher.awaitSynchronous();
 
-    if (statsEnabled) {
+    if (statsEnabled && (removed > 0)) {
       statistics.recordRemovals(removed);
       statistics.recordRemoveTime(ticker.read() - start);
     }

--- a/jcache/src/test/java/com/github/benmanes/caffeine/jcache/CacheProxyTest.java
+++ b/jcache/src/test/java/com/github/benmanes/caffeine/jcache/CacheProxyTest.java
@@ -488,6 +488,52 @@ final class CacheProxyTest {
   }
 
   @Test
+  @SuppressWarnings("PreferJavaTimeOverload")
+  void putTime_noOpOperations_notRecorded() {
+    try (var fixture = jcacheFixture(Mockito.mock(), Mockito.mock(), Mockito.mock())) {
+      fixture.ticker().setAutoIncrementStep(1, TimeUnit.SECONDS);
+      fixture.jcache().put(KEY_1, VALUE_1);
+
+      var stats = JCacheFixture.getStatistics(fixture.jcache());
+      float baseline = stats.getAveragePutTime();
+      assertThat(baseline).isGreaterThan(0F);
+
+      // Operations that store nothing must not accumulate put time against the put count.
+      assertThat(fixture.jcache().putIfAbsent(KEY_1, VALUE_2)).isFalse();
+      assertThat(fixture.jcache().replace(KEY_2, VALUE_1)).isFalse();
+      assertThat(fixture.jcache().replace(KEY_1, VALUE_2, VALUE_3)).isFalse();
+      assertThat(fixture.jcache().getAndReplace(KEY_2, VALUE_1)).isNull();
+      fixture.jcache().putAll(Map.of());
+
+      assertThat(stats.getCachePuts()).isEqualTo(1);
+      assertThat(stats.getAveragePutTime()).isEqualTo(baseline);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("PreferJavaTimeOverload")
+  void removeTime_noOpOperations_notRecorded() {
+    try (var fixture = jcacheFixture(Mockito.mock(), Mockito.mock(), Mockito.mock())) {
+      fixture.jcache().put(KEY_1, VALUE_1);
+      fixture.ticker().setAutoIncrementStep(1, TimeUnit.SECONDS);
+      assertThat(fixture.jcache().remove(KEY_1)).isTrue();
+
+      var stats = JCacheFixture.getStatistics(fixture.jcache());
+      float baseline = stats.getAverageRemoveTime();
+      assertThat(baseline).isGreaterThan(0F);
+
+      // Operations that remove nothing must not accumulate remove time against the removal count.
+      assertThat(fixture.jcache().remove(KEY_2)).isFalse();
+      assertThat(fixture.jcache().remove(KEY_2, VALUE_1)).isFalse();
+      assertThat(fixture.jcache().getAndRemove(KEY_2)).isNull();
+      fixture.jcache().removeAll(Set.of(KEY_2));
+
+      assertThat(stats.getCacheRemovals()).isEqualTo(1);
+      assertThat(stats.getAverageRemoveTime()).isEqualTo(baseline);
+    }
+  }
+
+  @Test
   void loadAll_loading_executorRejects_notifiesListener() {
     Executor rejecting = task -> { throw new RejectedExecutionException("test"); };
     try (var fixture = JCacheFixture.builder()


### PR DESCRIPTION
**Average put/remove time is charged to operations that change nothing**

Chasing an inflated `getAveragePutTime` reading, I traced every write and delete path in `CacheProxy` and found the timing is recorded unconditionally while the matching count only moves when the entry is genuinely stored or removed. A `putIfAbsent` on a present key, a value-mismatched `replace`/`remove(K, V)`, an absent-key `getAndReplace`/`getAndRemove`, and an empty `putAll`/`removeAll` each add their duration to the numerator with no put or removal in the denominator, so the reported mean is skewed high. The two-arg `replace(K, V)` and the iterator's `remove()` already gate the timing behind the mutation, and the JSR-107 reference implementation only accumulates the time when a put or removal occurs, which points to the other paths being an oversight rather than a deliberate choice.

Left unfixed, any workload that leans on conditional writes reports a put or remove latency several times higher than the operations that were actually counted, which quietly misleads anyone using the JMX statistics to reason about cache cost. Each timing call is now gated on the same condition as its counter, with a regression covering the no-op put and remove variants. Verified with `:jcache:test` and `:jcache:tckTest`.