### PR TITLE
Add @Nullable annotations required when treating Map.remove as returning @Nullable

### DIFF
--- a/caffeine/src/lincheckTest/java/com/github/benmanes/caffeine/cache/AbstractLincheckCacheTest.java
+++ b/caffeine/src/lincheckTest/java/com/github/benmanes/caffeine/cache/AbstractLincheckCacheTest.java
@@ -131,7 +131,7 @@ abstract class AbstractLincheckCacheTest {
   }
 
   @Operation
-  public Integer remove(@Param(name = "key") int key) {
+  public @Nullable Integer remove(@Param(name = "key") int key) {
     return cache.asMap().remove(key);
   }
 

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
@@ -451,7 +451,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
       }
       return replaced;
     }
-    @Override public CompletableFuture<V> remove(Object key) {
+    @Override public @Nullable CompletableFuture<V> remove(Object key) {
       return asyncCache.cache().remove(key);
     }
     @Override public boolean remove(Object key, Object value) {


### PR DESCRIPTION
The next release of NullAway treats `Map.remove` as returning `@Nullable`, leading to errors at these locations.  Fix them by marking the return type as `@Nullable`.