### PR TITLE
Replace awkward string manipulation with a simple mapping from `Feature`

### DIFF
--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/FactoryGenerator.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/FactoryGenerator.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.toImmutableEnumSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,11 +31,11 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.UnaryOperator;
 import java.util.spi.ToolProvider;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
@@ -50,12 +51,12 @@ import com.palantir.javapoet.TypeSpec;
 final class FactoryGenerator {
   private final ImmutableList<ImmutableSet<Feature>> featureCombinations;
   private final ImmutableList<Feature> canonicalOrder;
-  private final UnaryOperator<String> encode;
+  private final ImmutableMap<Feature, String> encoding;
   private final SpecFactory specFactory;
   private final Path directory;
 
   FactoryGenerator(Path directory, ImmutableList<ImmutableSet<Optional<Feature>>> dimensions,
-      UnaryOperator<String> encode, SpecFactory specFactory) {
+      ImmutableMap<Feature, String> encoding, SpecFactory specFactory) {
     requireNonNull(dimensions);
     this.featureCombinations = Sets.cartesianProduct(dimensions).stream()
         .map(FactoryGenerator::toFeatures).collect(toImmutableList());
@@ -65,7 +66,7 @@ final class FactoryGenerator {
         .flatMap(Optional::stream)
         .collect(toImmutableList());
     this.directory = requireNonNull(directory);
-    this.encode = requireNonNull(encode);
+    this.encoding = requireNonNull(encoding);
   }
 
   void generate() throws IOException {
@@ -101,7 +102,8 @@ final class FactoryGenerator {
 
   /** Returns the encoded class name, naming the features in canonical (not set iteration) order. */
   private String classNameOf(ImmutableSet<Feature> features) {
-    return encode.apply(Feature.makeClassName(canonical(features)));
+    var ordered = canonical(features);
+    return ordered.stream().map(encoding::get).collect(joining());
   }
 
   /** Orders the present features by the matrix dimension order, regardless of the set's own order. */

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/Feature.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/Feature.java
@@ -15,15 +15,11 @@
  */
 package com.github.benmanes.caffeine.cache;
 
-import static java.util.stream.Collectors.joining;
-
 import java.util.Collections;
 import java.util.Set;
 
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Streams;
 
 /**
  * The features that may be code generated.
@@ -52,17 +48,6 @@ public enum Feature {
   private static final ImmutableSet<Feature> fastPathIncompatible = Sets.immutableEnumSet(
       Feature.EXPIRE_ACCESS, Feature.WEAK_KEYS, Feature.INFIRM_VALUES,
       Feature.WEAK_VALUES, Feature.SOFT_VALUES);
-
-  public static String makeEnumName(String enumName) {
-    return CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, enumName);
-  }
-
-  public static String makeClassName(Iterable<Feature> features) {
-    String enumName = Streams.stream(features)
-        .map(Feature::name)
-        .collect(joining("_"));
-    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, enumName);
-  }
 
   public static boolean usesWriteOrderDeque(Set<Feature> features) {
     return features.contains(Feature.EXPIRE_WRITE);

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/LocalCacheFactoryGenerator.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/LocalCacheFactoryGenerator.java
@@ -41,6 +41,7 @@ import com.github.benmanes.caffeine.cache.local.AddSubtype;
 import com.github.benmanes.caffeine.cache.local.Finalize;
 import com.github.benmanes.caffeine.cache.local.LocalCacheContext;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.ParameterizedTypeName;
@@ -53,6 +54,22 @@ import com.palantir.javapoet.TypeSpec;
  * @author ben.manes@gmail.com (Ben Manes)
  */
 public final class LocalCacheFactoryGenerator {
+
+  private static final ImmutableMap<Feature, String> ENCODING_MAP =
+      ImmutableMap.<Feature, String>builder()
+          .put(Feature.STRONG_KEYS, "S")
+          .put(Feature.WEAK_KEYS, "W")
+          .put(Feature.STRONG_VALUES, "S")
+          .put(Feature.INFIRM_VALUES, "I")
+          .put(Feature.LISTENING, "L")
+          .put(Feature.STATS, "S")
+          .put(Feature.MAXIMUM_SIZE, "MS")
+          .put(Feature.MAXIMUM_WEIGHT, "MW")
+          .put(Feature.EXPIRE_ACCESS, "A")
+          .put(Feature.EXPIRE_WRITE, "W")
+          .put(Feature.REFRESH_WRITE, "R")
+          .buildOrThrow();
+
   private final ImmutableList<Rule<LocalCacheContext>> rules;
   private final ImmutableList<ImmutableSet<Optional<Feature>>> dimensions;
 
@@ -71,7 +88,7 @@ public final class LocalCacheFactoryGenerator {
 
   private void generate(Path directory) throws IOException {
     var generator = new FactoryGenerator(directory, dimensions,
-        LocalCacheFactoryGenerator::encode, this::makeLocalCacheSpec);
+        ENCODING_MAP, this::makeLocalCacheSpec);
     generator.generate();
   }
 
@@ -86,24 +103,6 @@ public final class LocalCacheFactoryGenerator {
       rule.run(context);
     }
     return context.build();
-  }
-
-  /** Returns an encoded form of the class name for compact use. */
-  private static String encode(String className) {
-    return Feature.makeEnumName(className)
-        .replaceFirst("STRONG_KEYS", "S")
-        .replaceFirst("WEAK_KEYS", "W")
-        .replaceFirst("STRONG_VALUES", "S")
-        .replaceFirst("INFIRM_VALUES", "I")
-        .replaceFirst("LISTENING", "L")
-        .replaceFirst("STATS", "S")
-        .replaceFirst("MAXIMUM", "M")
-        .replaceFirst("WEIGHT", "W")
-        .replaceFirst("SIZE", "S")
-        .replaceFirst("EXPIRE_ACCESS", "A")
-        .replaceFirst("EXPIRE_WRITE", "W")
-        .replaceFirst("REFRESH_WRITE", "R")
-        .replace("_", "");
   }
 
   public static void main(String[] args) throws IOException {

--- a/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/NodeFactoryGenerator.java
+++ b/caffeine/src/javaPoet/java/com/github/benmanes/caffeine/cache/NodeFactoryGenerator.java
@@ -37,6 +37,7 @@ import com.github.benmanes.caffeine.cache.node.AddValue;
 import com.github.benmanes.caffeine.cache.node.Finalize;
 import com.github.benmanes.caffeine.cache.node.NodeContext;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.ParameterizedTypeName;
@@ -50,6 +51,19 @@ import com.palantir.javapoet.TypeSpec;
  * @author ben.manes@gmail.com (Ben Manes)
  */
 public final class NodeFactoryGenerator {
+
+  private static final ImmutableMap<Feature, String> ENCODING_MAP = ImmutableMap.of(
+      Feature.STRONG_KEYS, /* puissant */ "P",
+      Feature.WEAK_KEYS, /* faible */ "F",
+      Feature.STRONG_VALUES, "S",
+      Feature.WEAK_VALUES, "W",
+      Feature.SOFT_VALUES, /* doux */ "D",
+      Feature.EXPIRE_ACCESS, "A",
+      Feature.EXPIRE_WRITE, "W",
+      Feature.REFRESH_WRITE, "R",
+      Feature.MAXIMUM_SIZE, "MS",
+      Feature.MAXIMUM_WEIGHT, "MW");
+
   private final ImmutableList<Rule<NodeContext>> rules;
   private final ImmutableList<ImmutableSet<Optional<Feature>>> dimensions;
 
@@ -65,8 +79,7 @@ public final class NodeFactoryGenerator {
   }
 
   private void generate(Path directory) throws IOException {
-    var generator = new FactoryGenerator(directory, dimensions,
-        NodeFactoryGenerator::encode, this::makeNodeSpec);
+    var generator = new FactoryGenerator(directory, dimensions, ENCODING_MAP, this::makeNodeSpec);
     generator.generate();
   }
 
@@ -82,23 +95,6 @@ public final class NodeFactoryGenerator {
       rule.run(context);
     }
     return context.build();
-  }
-
-  /** Returns an encoded form of the class name for compact use. */
-  private static String encode(String className) {
-    return Feature.makeEnumName(className)
-        .replaceFirst("STRONG_KEYS", /* puissant */ "P")
-        .replaceFirst("WEAK_KEYS", /* faible */ "F")
-        .replaceFirst("STRONG_VALUES", "S")
-        .replaceFirst("WEAK_VALUES", "W")
-        .replaceFirst("SOFT_VALUES", /* doux */ "D")
-        .replaceFirst("EXPIRE_ACCESS", "A")
-        .replaceFirst("EXPIRE_WRITE", "W")
-        .replaceFirst("REFRESH_WRITE", "R")
-        .replaceFirst("MAXIMUM", "M")
-        .replaceFirst("WEIGHT", "W")
-        .replaceFirst("SIZE", "S")
-        .replace("_", "");
   }
 
   public static void main(String[] args) throws IOException {


### PR DESCRIPTION
PR #1996 reverted a change that had been made for performance reasons, but I noticed that that code was doing some really awkward and unnecessary things already... this change should be a better performance improvement while also making the code more logical.

The code was previously taking a list of `Feature`s and:

1. Mapping it to an upper-underscore string.
2. Converting that to an upper-camel string.
3. Converting that _back_ to upper-underscore.
4. Using string replacement to convert the feature names to short strings and remove underscores.

This is an awkward and roundabout way of mapping each `Feature` to a short string and then joining those to a string, so this just changes it to actually work that way.