### PR TITLE
Use new jspecifyExperimental flag from nullaway plugin

### DIFF
--- a/gradle/plugins/src/main/kotlin/quality/errorprone.caffeine.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/quality/errorprone.caffeine.gradle.kts
@@ -80,9 +80,9 @@ tasks.withType<JavaCompile>().configureEach {
         suggestSuppressions = true
         checkContracts = true
         jspecifyMode = true
+        jspecifyExperimental = true
         error()
       }
-      errorproneArgs.add("-XepOpt:NullAway:JSpecifyExperimental=true")
     }
   }
 }


### PR DESCRIPTION
Supported as of plugin [version 3.2.0](https://github.com/tbroyer/gradle-nullaway-plugin/releases/tag/v3.2.0)