### PR TITLE
Remove unrecognized JSpecify local annotations

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncCache.java
@@ -194,7 +194,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
     return CompletableFuture.allOf(array).thenApply(ignored -> {
       var result = new LinkedHashMap<K, V>(calculateHashMapCapacity(futures.size()));
       futures.forEach((key, future) -> {
-        @Nullable V value = future.getNow(null);
+        V value = future.getNow(null);
         if (value != null) {
           result.put(key, value);
         }
@@ -508,7 +508,7 @@ interface LocalAsyncCache<K, V> extends AsyncCache<K, V> {
         deferred[0] = !Async.isReady(result[0]);
         return result[0];
       };
-      @Nullable CompletableFuture<V> future = asyncCache.cache().computeIfAbsent(
+      CompletableFuture<V> future = asyncCache.cache().computeIfAbsent(
           key, function, /* recordStats= */ true, /* recordLoad= */ false);
       if (result[0] != null) {
         asyncCache.handleCompletion(key, result[0], startTime, deferred[0], /* computed= */ true);


### PR DESCRIPTION
## Why
NullAway’s JSpecify checker reports root-type nullness annotations on local variables as unrecognized locations. With -Werror, the two warnings in LocalAsyncCache fail compilation.

## What
Remove the two root local-variable annotations. Their nullability is still handled by the existing null checks, and no nested type-use annotation changes.

## Verification
./gradlew --quiet :caffeine:compileJava

Related: https://github.com/uber/NullAway/pull/1787