### PR TITLE
Remove nullness annotations on local variable root types

### DIFF
--- a/.claude/rules/errorprone.md
+++ b/.claude/rules/errorprone.md
@@ -14,7 +14,6 @@ paths:
 ## Common Patterns
 - **Lazy initialization**: fields initialized after construction (e.g., `FrequencySketch.ensureCapacity()`) may need `@SuppressWarnings("NullAway.Init")`
 - **Nullable in non-nullable context**: intentional null returns in framework methods (e.g., CHM compute returning null to remove) may need `@SuppressWarnings({"DataFlowIssue", "NullAway"})`
-- **`var` erases `@Nullable`**: assigning an expression whose inferred type carries `@Nullable` (a stream `.reduce(...).orElse(null)`, a lambda/method result) to `var` widens it to non-null, so returning/using it where an `@Nullable` type is declared fails NullAway (`incompatible types: T cannot be converted to @Nullable T`). Give the local an explicit `@Nullable`-typed declaration, or return the expression directly instead of via a `var` local
 - **Cross-class `@GuardedBy`**: EP doesn't support it (e.g., FrequencySketch guarded by BoundedLocalCache.evictionLock). Don't add cross-class annotations; concurrency tests are the safety net
 - **`UnnecessarySemicolon`**: disabled due to upstream EP bug (google/error-prone#5548), don't re-enable
 

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -1377,7 +1377,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
         @Nullable RemovalCause[] cause = new RemovalCause[1];
         var hints = new RemapHints();
         hints.quietly = true;
-        @Nullable V result;
+        V result;
         try {
           result = compute(key, (K k, @Nullable V currentValue) -> {
             // Keep the refresh registered until the write clears it to avoid readers from
@@ -2231,7 +2231,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
     // Remove any stragglers if released early to more aggressively flush incoming writes
     @Var boolean cleanUp = false;
     for (var node : entries) {
-      @Nullable K key = node.getKey();
+      var key = node.getKey();
       if (key == null) {
         cleanUp = true;
       } else {
@@ -2869,7 +2869,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
           tryExpireAfterRead(node, key, value, expiry(), now);
           setAccessTime(node, now);
         }
-        @Nullable V refreshed = afterRead(node, now, /* recordHit= */ recordStats);
+        var refreshed = afterRead(node, now, /* recordHit= */ recordStats);
         return (refreshed == null) ? value : refreshed;
       }
     }
@@ -2974,7 +2974,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
         setAccessTime(node, ctx.now);
       }
 
-      @Nullable V refreshed = afterRead(node, ctx.now, /* recordHit= */ recordStats);
+      var refreshed = afterRead(node, ctx.now, /* recordHit= */ recordStats);
       return (refreshed == null) ? ctx.oldValue : refreshed;
     }
     if ((ctx.oldValue == null) && (ctx.cause == null)) {
@@ -2995,7 +2995,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
 
     // An optimistic fast path to avoid unnecessary locking
     Object lookupKey = nodeFactory.newLookupKey(key);
-    @Nullable Node<K, V> node = data.get(lookupKey);
+    var node = data.get(lookupKey);
     long now;
     if (node == null) {
       return null;
@@ -4443,7 +4443,7 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
         var inFlight = new IdentityHashMap<K, CompletableFuture<V>>(refreshes.size());
         for (var entry : refreshes.entrySet()) {
           @SuppressWarnings("unchecked")
-          @Nullable K key = ((InternalReference<K>) entry.getKey()).get();
+          var key = ((InternalReference<K>) entry.getKey()).get();
           @SuppressWarnings("unchecked")
           var future = (CompletableFuture<V>) entry.getValue();
           if (key != null) {

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Interner.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Interner.java
@@ -92,7 +92,7 @@ final class StrongInterner<E> implements Interner<E> {
       return canonical;
     }
 
-    @Nullable E value = map.putIfAbsent(sample, sample);
+    var value = map.putIfAbsent(sample, sample);
     return (value == null) ? sample : value;
   }
 }

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalLoadingCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalLoadingCache.java
@@ -142,7 +142,7 @@ interface LocalLoadingCache<K, V> extends LocalManualCache<K, V>, LoadingCache<K
         try {
           var discard = new boolean[1];
           var hints = new LocalCache.RemapHints();
-          @Nullable V value = cache().compute(key, (K k, @Nullable V currentValue) -> {
+          var value = cache().compute(key, (K k, @Nullable V currentValue) -> {
             // Keep the refresh registered until the write clears it to avoid refreshAfterWrite
             // readers from prematurely scheduling another reload
             boolean owned = (cache().refreshes().get(keyReference) == reloading[0]);

--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/MpscGrowableArrayQueue.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/MpscGrowableArrayQueue.java
@@ -339,7 +339,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
     long mask = consumerMask;
 
     long offset = modifiedCalcElementOffset(index, mask);
-    @Var @Nullable Object e = lvElement(buffer, offset);// LoadLoad
+    @Var Object e = lvElement(buffer, offset);// LoadLoad
     if (e == null) {
       if (index != lvProducerIndex(this)) {
         // poll() == null iff queue is empty, null element is not strong enough indicator, so we
@@ -375,7 +375,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
     long mask = consumerMask;
 
     long offset = modifiedCalcElementOffset(index, mask);
-    @Var @Nullable Object e = lvElement(buffer, offset);// LoadLoad
+    @Var Object e = lvElement(buffer, offset);// LoadLoad
     if (e == null && index != lvProducerIndex(this)) {
       // peek() == null iff queue is empty, null element is not strong enough indicator, so we must
       // check the producer index. If the queue is indeed not empty we spin until element is
@@ -405,7 +405,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
 
   private E newBufferPoll(@Nullable E[] nextBuffer, long index) {
     long offsetInNew = newBufferAndOffset(nextBuffer, index);
-    @Nullable E n = lvElement(nextBuffer, offsetInNew);// LoadLoad
+    var n = lvElement(nextBuffer, offsetInNew);// LoadLoad
     requireNonNull(n, "new buffer must have at least one element");
     soElement(nextBuffer, offsetInNew, null);// StoreStore
     soConsumerIndex(this, index + 2);
@@ -414,7 +414,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
 
   private E newBufferPeek(@Nullable E[] nextBuffer, long index) {
     long offsetInNew = newBufferAndOffset(nextBuffer, index);
-    @Nullable E n = lvElement(nextBuffer, offsetInNew);// LoadLoad
+    var n = lvElement(nextBuffer, offsetInNew);// LoadLoad
     requireNonNull(n, "new buffer must have at least one element");
     return n;
   }
@@ -485,7 +485,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
     long mask = consumerMask;
 
     long offset = modifiedCalcElementOffset(index, mask);
-    @Nullable Object e = lvElement(buffer, offset);// LoadLoad
+    Object e = lvElement(buffer, offset);// LoadLoad
     if (e == null) {
       return null;
     }
@@ -505,7 +505,7 @@ abstract class BaseMpscLinkedArrayQueue<E> extends BaseMpscLinkedArrayQueueColdP
     long mask = consumerMask;
 
     long offset = modifiedCalcElementOffset(index, mask);
-    @Nullable Object e = lvElement(buffer, offset);// LoadLoad
+    Object e = lvElement(buffer, offset);// LoadLoad
     if (e == JUMP) {
       return newBufferPeek(getNextBuffer(buffer, mask), index);
     }

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/CacheProxy.java
@@ -799,7 +799,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
 
     boolean statsEnabled = statistics.isEnabled();
     long start = statsEnabled ? ticker.read() : 0L;
-    @Nullable V oldValue = replaceNoCopyOrAwait(key, value);
+    var oldValue = replaceNoCopyOrAwait(key, value);
     var listenerFailure = awaitSynchronousFailure();
     if (oldValue == null) {
       statistics.recordMisses(1L);
@@ -968,7 +968,7 @@ public class CacheProxy<K, V> implements Cache<K, V> {
       // Publish a lazily-expired prior's expiration before the processor observes it as absent,
       // so listeners see a linearizable sequence and the expiration is committed exactly once
       boolean expired;
-      @Nullable Expirable<V> prior;
+      Expirable<V> prior;
       if ((expirable != null) && !expirable.isEternal()
           && expirable.hasExpired(currentTimeMillis())) {
         dispatcher.publishExpired(this, key, expirable.get());

--- a/jcache/src/main/java/com/github/benmanes/caffeine/jcache/LoadingCacheProxy.java
+++ b/jcache/src/main/java/com/github/benmanes/caffeine/jcache/LoadingCacheProxy.java
@@ -60,7 +60,7 @@ public final class LoadingCacheProxy<K, V> extends CacheProxy<K, V> {
   @Override
   public @Nullable V get(K key) {
     requireOperable();
-    @Nullable V value;
+    V value;
     try {
       value = getOrLoad(key);
     } catch (NullPointerException | IllegalStateException | ClassCastException | CacheException e) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/BasicSettings.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/BasicSettings.java
@@ -118,7 +118,7 @@ public class BasicSettings {
       return getter.apply(path);
     } catch (ConfigException.Parse | ConfigException.WrongType e) {
       var matcher = NUMERIC_SEPARATOR.matcher(config().getString(path));
-      @Nullable T value = tryParse.apply(matcher.replaceAll(""));
+      var value = tryParse.apply(matcher.replaceAll(""));
       if (value == null) {
         throw e;
       }

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/ArcPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/ArcPolicy.java
@@ -88,7 +88,7 @@ public final class ArcPolicy implements KeyOnlyPolicy {
   @Override
   public void record(long key) {
     policyStats.recordOperation();
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     if (node == null) {
       onMiss(key);
     } else if (node.type == QueueType.B1) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/CacheusPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/adaptive/CacheusPolicy.java
@@ -24,8 +24,6 @@ import java.util.Random;
 import java.util.SequencedMap;
 import java.util.TreeSet;
 
-import org.jspecify.annotations.Nullable;
-
 import com.github.benmanes.caffeine.cache.simulator.BasicSettings;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.KeyOnlyPolicy;
 import com.github.benmanes.caffeine.cache.simulator.policy.Policy.PolicySpec;
@@ -148,7 +146,7 @@ public final class CacheusPolicy implements KeyOnlyPolicy {
     time++;
     updateLearningRate();
 
-    @Var @Nullable Node node;
+    @Var Node node;
     if ((node = s.get(key)) != null) {
       hitInS(node);
       policyStats.recordHit();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/CampPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/CampPolicy.java
@@ -90,7 +90,7 @@ public final class CampPolicy implements Policy {
 
   @Override
   public void record(AccessEvent event) {
-    @Nullable Node node = data.get(event.key());
+    var node = data.get(event.key());
     maxSize = Math.max(maxSize, event.weight());
     if (node == null) {
       policyStats.recordWeightedMiss(event.weight());

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GDWheelPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GDWheelPolicy.java
@@ -76,7 +76,7 @@ public final class GDWheelPolicy implements Policy {
 
   @Override
   public void record(AccessEvent event) {
-    @Var @Nullable Node node = data.get(event.key());
+    @Var var node = data.get(event.key());
     policyStats.recordOperation();
     if (node == null) {
       policyStats.recordWeightedMiss(event.weight());

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GdsfPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/greedy_dual/GdsfPolicy.java
@@ -73,7 +73,7 @@ public final class GdsfPolicy implements Policy {
 
   @Override
   public void record(AccessEvent event) {
-    @Nullable Node node = data.get(event.key());
+    var node = data.get(event.key());
     if (node == null) {
       policyStats.recordWeightedMiss(event.weight());
       onMiss(event);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPlusPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPlusPolicy.java
@@ -167,7 +167,7 @@ public final class ClockProPlusPolicy implements KeyOnlyPolicy {
     lastKey = key;
     hasLastKey = true;
     policyStats.recordOperation();
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     if (node == null) {
       node = new Node(key);
       data.put(key, node);
@@ -522,7 +522,7 @@ public final class ClockProPlusPolicy implements KeyOnlyPolicy {
     @Var int nonResColdSize = 0;
     @Var int recentlyDemotedSize = 0;
 
-    @Var @Nullable Node node = listHead;
+    @Var var node = listHead;
     do {
       if (node == null) {
         break;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProPolicy.java
@@ -149,7 +149,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     lastKey = key;
     hasLastKey = true;
     policyStats.recordOperation();
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     if (node == null) {
       node = new Node(key);
       data.put(key, node);
@@ -464,7 +464,7 @@ public final class ClockProPolicy implements KeyOnlyPolicy {
     @Var int resColdSize = 0;
     @Var int nonResColdSize = 0;
 
-    @Var @Nullable Node node = listHead;
+    @Var var node = listHead;
     do {
       if (node == null) {
         break;

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimplePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/ClockProSimplePolicy.java
@@ -151,7 +151,7 @@ public final class ClockProSimplePolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     if (node == null) {
       onMiss(key);
     } else if (node.status == Status.HOT || node.status == Status.COLD) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/DClockPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/DClockPolicy.java
@@ -93,7 +93,7 @@ public final class DClockPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     if (node == null) {
       onMiss(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/FrdPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/FrdPolicy.java
@@ -79,7 +79,7 @@ public final class FrdPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     policyStats.recordOperation();
     if (node == null) {
       node = new Node(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/HillClimberFrdPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/HillClimberFrdPolicy.java
@@ -79,7 +79,7 @@ public final class HillClimberFrdPolicy implements KeyOnlyPolicy {
     policyStats.recordOperation();
     adapt();
 
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     if (node == null) {
       node = new Node(key);
       data.put(key, node);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/IndicatorFrdPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/IndicatorFrdPolicy.java
@@ -74,7 +74,7 @@ public final class IndicatorFrdPolicy implements KeyOnlyPolicy {
     policyStats.recordOperation();
     adapt(key);
 
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     if (node == null) {
       node = new Node(key);
       data.put(key, node);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/Lirs2Policy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/Lirs2Policy.java
@@ -129,7 +129,7 @@ public final class Lirs2Policy implements KeyOnlyPolicy {
     lastKey = key;
     hasLastKey = true;
 
-    @Var @Nullable Block block = data.get(key);
+    @Var var block = data.get(key);
     policyStats.recordOperation();
     if (block == null) {
       block = new Block(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/irr/LirsPolicy.java
@@ -95,7 +95,7 @@ public final class LirsPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     policyStats.recordOperation();
     if (node == null) {
       node = new Node(key);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/FrequentlyUsedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/FrequentlyUsedPolicy.java
@@ -76,7 +76,7 @@ public final class FrequentlyUsedPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/LinkedPolicy.java
@@ -87,7 +87,7 @@ public final class LinkedPolicy implements Policy {
   public void record(AccessEvent event) {
     int weight = weighted ? event.weight() : 1;
     long key = event.key();
-    @Nullable Node old = data.get(key);
+    var old = data.get(key);
     admitter.record(key);
     if (old == null) {
       policyStats.recordWeightedMiss(weight);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/MultiQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/MultiQueuePolicy.java
@@ -82,7 +82,7 @@ public final class MultiQueuePolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     policyStats.recordOperation();
     if (node == null) {
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/S4LruPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/S4LruPolicy.java
@@ -82,7 +82,7 @@ public final class S4LruPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/SegmentedLruPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/SegmentedLruPolicy.java
@@ -90,7 +90,7 @@ public final class SegmentedLruPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/SievePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/linked/SievePolicy.java
@@ -66,7 +66,7 @@ public final class SievePolicy implements Policy {
 
   @Override
   public void record(AccessEvent event) {
-    @Nullable Node node = data.get(event.key());
+    var node = data.get(event.key());
     policyStats.recordOperation();
     if (node == null) {
       onMiss(event);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/WindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/WindowTinyLfuPolicy.java
@@ -137,7 +137,7 @@ public final class WindowTinyLfuPolicy implements Policy {
 
   @Override
   public void record(AccessEvent event) {
-    @Nullable Node node = data.get(event.key());
+    var node = data.get(event.key());
     int weight = weighted ? event.weight() : 1;
     policyStats.recordOperation();
     if (node == null) {
@@ -255,7 +255,7 @@ public final class WindowTinyLfuPolicy implements Policy {
    * returning the first demoted candidate.
    */
   private @Nullable Node evictFromWindow() {
-    @Var @Nullable Node first = null;
+    @Var Node first = null;
     while (sizeWindow > maxWindow) {
       Node candidate = requireNonNull(headWindow.next);
       candidate.remove();
@@ -280,7 +280,7 @@ public final class WindowTinyLfuPolicy implements Policy {
   private void evictFromMain(@Var @Nullable Node candidate) {
     @Var boolean searchedWindow = false;
     @Var Node victimHead = headProbation;
-    @Var @Nullable Node victim = first(headProbation);
+    @Var var victim = first(headProbation);
     while (sizeData > maximumSize) {
       // search the admission window for additional candidates
       if ((candidate == null) && !searchedWindow) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/HillClimberWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/climbing/HillClimberWindowTinyLfuPolicy.java
@@ -116,7 +116,7 @@ public final class HillClimberWindowTinyLfuPolicy implements KeyOnlyPolicy {
   @Override
   public void record(long key) {
     boolean isFull = (data.size() >= maximumSize);
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackTinyLfuPolicy.java
@@ -99,7 +99,7 @@ public final class FeedbackTinyLfuPolicy implements KeyOnlyPolicy {
 
     admitter.record(key);
     policyStats.recordOperation();
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     if (node == null) {
       onMiss(key);
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/feedback/FeedbackWindowTinyLfuPolicy.java
@@ -137,7 +137,7 @@ public final class FeedbackWindowTinyLfuPolicy implements KeyOnlyPolicy {
 
     admitter.record(key);
     policyStats.recordOperation();
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     if (node == null) {
       onMiss(key);
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/FullySegmentedWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/FullySegmentedWindowTinyLfuPolicy.java
@@ -96,7 +96,7 @@ public final class FullySegmentedWindowTinyLfuPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/LruWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/LruWindowTinyLfuPolicy.java
@@ -83,7 +83,7 @@ public final class LruWindowTinyLfuPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
 

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/RandomWindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/RandomWindowTinyLfuPolicy.java
@@ -84,7 +84,7 @@ public final class RandomWindowTinyLfuPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     admitter.record(key);
     if (node == null) {
       node = new Node(key, windowSize);

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/S4WindowTinyLfuPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/sketch/segment/S4WindowTinyLfuPolicy.java
@@ -89,7 +89,7 @@ public final class S4WindowTinyLfuPolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     admitter.record(key);
     if (node == null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/S3FifoPolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/S3FifoPolicy.java
@@ -94,7 +94,7 @@ public final class S3FifoPolicy implements Policy {
 
   @Override
   public void record(AccessEvent event) {
-    @Var @Nullable Node node;
+    @Var Node node;
     if ((node = dataSmall.get(event.key())) != null) {
       onHit(event, node, change -> sizeSmall += change);
     } else if ((node = dataMain.get(event.key())) != null) {

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TuQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TuQueuePolicy.java
@@ -86,7 +86,7 @@ public final class TuQueuePolicy implements KeyOnlyPolicy {
 
   @Override
   public void record(long key) {
-    @Nullable Node node = data.get(key);
+    var node = data.get(key);
     policyStats.recordOperation();
     if (node == null) {
       policyStats.recordMiss();

--- a/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TwoQueuePolicy.java
+++ b/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/policy/two_queue/TwoQueuePolicy.java
@@ -93,7 +93,7 @@ public final class TwoQueuePolicy implements KeyOnlyPolicy {
     //     add X to the head of Alin
     //   end if
 
-    @Var @Nullable Node node = data.get(key);
+    @Var var node = data.get(key);
     policyStats.recordOperation();
     if (node != null) {
       requireNonNull(node.type);


### PR DESCRIPTION
JSpecify does not recognize a nullness annotation on the root type of a local variable, so `@Nullable V value = cache().compute(...)` makes no claim about nullness even though it reads like one. NullAway's new `JSpecifyUnrecognizedAnnotationLocation` check reports each of them:

```text
A nullness annotation on the root type of a local variable has no meaning under JSpecify.
```

The build promotes every Error Prone suggestion to a warning (`allSuggestionsAsWarnings`) and CI compiles with `-Werror`, so the 53 annotations left in caffeine, jcache and simulator fail the build as soon as the check is released. #2008 removed the first two, and the `Build caffeine with snapshot` job of uber/NullAway#1787 is red on the rest today.

Drop the annotation, and let `var` carry the declaration wherever the local allows it, which is 43 of the 53. The null checks, the nested type-use annotations such as `(K k, @Nullable V currentValue) ->`, and `@Var` stay where they are. Ten declarations keep an explicit type for reasons that have nothing to do with nullness: five have no initializer, `WindowTinyLfuPolicy.evictFromWindow` initializes from `null`, which javac cannot infer a type from, and the four reads of `lvElement` in `MpscGrowableArrayQueue` are declared `Object` on purpose, since `var` there infers `E` and makes the `(E) e` casts that follow redundant.

`.claude/rules/errorprone.md` warned that `var` widens an inferred `@Nullable` type to non-null, and told the reader to give the local an explicit `@Nullable`-typed declaration, which is the annotation this check reports. The bullet was written against NullAway 0.13.8 and no longer holds: its own example, `values.stream().reduce(...).orElse(null)` assigned to a local and returned as `@Nullable T`, compiles clean under 0.14.2-SNAPSHOT both with `var` and with an explicit type, as do the 43 locals converted here. Remove it.

Every Java compile task in the four modules, tests and the specialized suites included, builds against a NullAway snapshot carrying the check and reports nothing. The jcache and simulator suites pass; the caffeine `@CacheSpec` matrix is left to CI.
