### PR TITLE
Fixes for upcoming NullAway warnings

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalLoadingCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalLoadingCache.java
@@ -54,6 +54,7 @@ interface LocalLoadingCache<K, V> extends LocalManualCache<K, V>, LoadingCache<K
   /** Returns the {@link CacheLoader#loadAll} as a mapping function, if implemented. */
   @Nullable Function<Set<? extends K>, Map<K, V>> bulkMappingFunction();
 
+  @SuppressWarnings("NullAway") // https://github.com/ben-manes/caffeine/issues/594
   @Override
   default V get(K key) {
     return cache().computeIfAbsent(key, mappingFunction());

--- a/caffeine/src/test/java/com/github/benmanes/caffeine/cache/BoundedLocalCacheTest.java
+++ b/caffeine/src/test/java/com/github/benmanes/caffeine/cache/BoundedLocalCacheTest.java
@@ -1979,7 +1979,8 @@ final class BoundedLocalCacheTest {
     cache.cleanUp();
 
     var listener = (ConsumingRemovalListener<Int, Int>) context.removalListener();
-    var actual = listener.removed().stream().map(Map.Entry::getKey).collect(toImmutableList());
+    var actual = listener.removed().stream()
+        .map(entry -> requireNonNull(entry.getKey())).collect(toImmutableList());
     assertThat(actual).containsExactlyElementsIn(expected).inOrder();
   }
 
@@ -2004,7 +2005,8 @@ final class BoundedLocalCacheTest {
     cache.evictEntries(0L);
 
     var listener = (ConsumingRemovalListener<Int, Int>) context.removalListener();
-    var actual = listener.removed().stream().map(Map.Entry::getKey).collect(toImmutableList());
+    var actual = listener.removed().stream()
+        .map(entry -> requireNonNull(entry.getKey())).collect(toImmutableList());
     assertThat(actual).containsExactlyElementsIn(expected).inOrder();
   }
 
@@ -2028,7 +2030,8 @@ final class BoundedLocalCacheTest {
     cache.evictEntries(0L);
 
     var listener = (ConsumingRemovalListener<Int, Int>) context.removalListener();
-    var actual = listener.removed().stream().map(Map.Entry::getKey).collect(toImmutableList());
+    var actual = listener.removed().stream()
+        .map(entry -> requireNonNull(entry.getKey())).collect(toImmutableList());
     assertThat(actual).containsExactlyElementsIn(expected).inOrder();
   }
 
@@ -2064,7 +2067,8 @@ final class BoundedLocalCacheTest {
     cache.evictEntries(0L);
 
     var listener = (ConsumingRemovalListener<Int, Int>) context.removalListener();
-    var actual = listener.removed().stream().map(Map.Entry::getKey).collect(toImmutableList());
+    var actual = listener.removed().stream()
+        .map(entry -> requireNonNull(entry.getKey())).collect(toImmutableList());
     assertThat(actual).containsExactlyElementsIn(expected).inOrder();
   }
 
@@ -2089,7 +2093,8 @@ final class BoundedLocalCacheTest {
     cache.evictEntries(0L);
 
     var listener = (ConsumingRemovalListener<Int, Int>) context.removalListener();
-    var actual = listener.removed().stream().map(Map.Entry::getKey).collect(toImmutableList());
+    var actual = listener.removed().stream()
+        .map(entry -> requireNonNull(entry.getKey())).collect(toImmutableList());
     assertThat(actual).containsExactlyElementsIn(expected).inOrder();
   }
 


### PR DESCRIPTION
Fixes #2012 

For #2012, we add a suppression.

The other fixes are due to https://github.com/uber/NullAway/pull/1804, which exposes the fact that `getKey()` can return null, which can't go into a Guava `ImmutableList`.  Codex suggested `requireNonNull` was appropriate for these.