### PR TITLE
Drop the cast that discarded the non-null bulk value type

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/AsyncCacheLoader.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/AsyncCacheLoader.java
@@ -167,13 +167,12 @@ public interface AsyncCacheLoader<K, V extends @Nullable Object> {
       @Override public CompletableFuture<@Nullable V> asyncLoad(K key, Executor executor) {
         return asyncLoadAll(Set.of(key), executor).thenApply(results -> results.get(key));
       }
-      @Override public CompletableFuture<Map<K, V>> asyncLoadAll(
+      @Override
+      public CompletableFuture<? extends Map<? extends K, ? extends @NonNull V>> asyncLoadAll(
           Set<? extends K> keys, Executor executor) {
         requireNonNull(keys);
         requireNonNull(executor);
-        @SuppressWarnings("unchecked")
-        var future = (CompletableFuture<Map<K, V>>) mappingFunction.apply(keys, executor);
-        return future;
+        return mappingFunction.apply(keys, executor);
       }
     };
   }


### PR DESCRIPTION
## Why

`AsyncCacheLoader.bulk(BiFunction)` returns an adapter whose `asyncLoadAll` was declared as `CompletableFuture<Map<K, V>>`, reached by an unchecked cast of the mapping function's future. The interface declares `CompletableFuture<? extends Map<? extends K, ? extends @NonNull V>>`, and the `bulk` parameter requires the same type, so the cast only widened `@NonNull V` to `V`. A loader typed as `AsyncCacheLoader<K, @Nullable Foo>` takes a mapping function that promises `Map<?, @NonNull Foo>`, and the adapter then declared `Map<K, @Nullable Foo>`, dropping the guarantee the javadoc states as `may not contain null values`.

There is no runtime symptom, because the mapping function's own type already forbids a null value. An upcoming NullAway release reports the mismatch ([uber/NullAway#1834](https://github.com/uber/NullAway/pull/1834)):

```text
error: [NullAway] Method returns CompletableFuture<Map<K, V>>, but overridden method returns CompletableFuture<? extends Map<? extends K, ? extends V>>, which has mismatched type parameter nullability
```

## What

Override with the interface's signature and return the mapping function's future unchanged, which removes both the cast and its `@SuppressWarnings("unchecked")`. `CacheLoader.bulk` already declares `loadAll` that way. Widening the interface to `? extends V` would admit null bulk values, which the cache refuses; suppressing the report would leave the adapter typed wrongly. The `@SuppressWarnings("NullAway")` on the neighboring `asyncLoad` stays, since a partial bulk result makes that method return null, and it is the counterpart of the documented suppression on `load()` in `CacheLoader.bulk`.

## Verification

Compiling every Java source set of the four modules against a NullAway build of that pull request, the specialized suites included, reports nothing; reverting this change reproduces the diagnostic above at `AsyncCacheLoader.java:170`. Removing the `asyncLoad` suppression reports the same mismatch for `CompletableFuture<@Nullable V>` against `CompletableFuture<? extends V>`, so it stays. The released NullAway 0.14.1 accepts both the old and the new code. `AsyncLoadingCacheTest.bulk_absent`, `bulk_present` and `bulk_bifunction_null` are the three tests that reach this adapter, and they pass unchanged.

## Scope

The new check reports nothing else in caffeine, guava, jcache or simulator. The signature change is confined to an anonymous class: `bulk` still returns `AsyncCacheLoader<K, V>`, and the erasure of the override is unchanged, so no caller and no compiled descriptor moves.
